### PR TITLE
Preserve package.json formatting when bumping versions

### DIFF
--- a/.bumpy/preserve-package-json-formatting.md
+++ b/.bumpy/preserve-package-json-formatting.md
@@ -1,0 +1,7 @@
+---
+'@varlock/bumpy': patch
+---
+
+Preserve package.json formatting when bumping versions
+
+Instead of re-serializing the entire file with `JSON.stringify`, version bumps and dependency range updates now use targeted string replacements. This prevents reformatting issues like inline arrays being expanded to multi-line, indentation style changes, and other unnecessary churn.

--- a/packages/bumpy/src/core/apply-release-plan.ts
+++ b/packages/bumpy/src/core/apply-release-plan.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readJson, writeJson, readText, writeText, exists } from '../utils/fs.ts';
+import { readJson, readText, writeText, exists, updateJsonFields, updateJsonNestedField } from '../utils/fs.ts';
 import { deleteChangesets } from './changeset.ts';
 import { generateChangelogEntry, prependToChangelog, loadFormatter } from './changelog.ts';
 import type { ReleasePlan, WorkspacePackage, BumpyConfig } from '../types.ts';
@@ -14,27 +14,26 @@ export async function applyReleasePlan(
   const releaseMap = new Map(releasePlan.releases.map((r) => [r.name, r]));
   const formatter = await loadFormatter(config.changelog, rootDir);
 
-  // 1. Update package.json versions and internal dependency ranges
+  // 1. Update package.json versions and internal dependency ranges (preserving formatting)
   for (const release of releasePlan.releases) {
     const pkg = packages.get(release.name)!;
     const pkgJsonPath = resolve(pkg.dir, 'package.json');
     const pkgJson = await readJson<Record<string, unknown>>(pkgJsonPath);
 
-    // Bump the version
-    pkgJson.version = release.newVersion;
+    // Bump the version (in-place string replacement)
+    await updateJsonFields(pkgJsonPath, { version: release.newVersion });
 
-    // Update internal dependency ranges
+    // Update internal dependency ranges (in-place string replacement)
     for (const depField of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const) {
       const deps = pkgJson[depField] as Record<string, string> | undefined;
       if (!deps) continue;
       for (const [depName, range] of Object.entries(deps)) {
         const depRelease = releaseMap.get(depName);
         if (!depRelease) continue;
-        deps[depName] = updateRange(range, depRelease.newVersion);
+        const newRange = updateRange(range, depRelease.newVersion);
+        await updateJsonNestedField(pkgJsonPath, depField, depName, newRange);
       }
     }
-
-    await writeJson(pkgJsonPath, pkgJson);
   }
 
   // 2. Update changelogs

--- a/packages/bumpy/src/core/publish-pipeline.ts
+++ b/packages/bumpy/src/core/publish-pipeline.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
-import { readJson, writeJson } from '../utils/fs.ts';
+import { readJson, updateJsonNestedField } from '../utils/fs.ts';
 import { runAsync, runArgsAsync, tryRunArgs, sq } from '../utils/shell.ts';
 import { log, colorize } from '../utils/logger.ts';
 import { createTag, tagExists } from './git.ts';
@@ -377,8 +377,6 @@ async function resolveProtocolsInPlace(
 ): Promise<void> {
   const pkgJsonPath = resolve(pkg.dir, 'package.json');
   const pkgJson = await readJson<Record<string, unknown>>(pkgJsonPath);
-  let modified = false;
-
   const releaseMap = new Map(releasePlan.releases.map((r) => [r.name, r]));
 
   for (const depField of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const) {
@@ -409,13 +407,8 @@ async function resolveProtocolsInPlace(
       }
 
       if (resolved) {
-        deps[depName] = resolved;
-        modified = true;
+        await updateJsonNestedField(pkgJsonPath, depField, depName, resolved);
       }
     }
-  }
-
-  if (modified) {
-    await writeJson(pkgJsonPath, pkgJson);
   }
 }

--- a/packages/bumpy/src/utils/fs.ts
+++ b/packages/bumpy/src/utils/fs.ts
@@ -10,6 +10,47 @@ export async function writeJson(filePath: string, data: unknown, indent = 2): Pr
   await writeFile(filePath, JSON.stringify(data, null, indent) + '\n', 'utf-8');
 }
 
+/**
+ * Update specific top-level string fields in a JSON file without reformatting.
+ * Reads the raw text, does targeted regex replacements, and writes it back.
+ */
+export async function updateJsonFields(filePath: string, updates: Record<string, string>): Promise<void> {
+  let content = await readFile(filePath, 'utf-8');
+  for (const [key, newValue] of Object.entries(updates)) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`("${escaped}"\\s*:\\s*)"[^"]*"`);
+    content = content.replace(pattern, `$1"${newValue}"`);
+  }
+  await writeFile(filePath, content, 'utf-8');
+}
+
+/**
+ * Update a nested string field inside a top-level object in a JSON file without reformatting.
+ * e.g., updateJsonNestedField(path, 'dependencies', 'core', '^2.0.0')
+ */
+export async function updateJsonNestedField(
+  filePath: string,
+  parentKey: string,
+  childKey: string,
+  newValue: string,
+): Promise<void> {
+  let content = await readFile(filePath, 'utf-8');
+  const parentEscaped = parentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const childEscaped = childKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  // Find the parent object block and replace the child value within it
+  const parentPattern = new RegExp(
+    `("${parentEscaped}"\\s*:\\s*\\{)([^}]*)\\}`,
+    's', // dotAll so . matches newlines
+  );
+  content = content.replace(parentPattern, (match, prefix, body) => {
+    const childPattern = new RegExp(`("${childEscaped}"\\s*:\\s*)"[^"]*"`);
+    const newBody = body.replace(childPattern, `$1"${newValue}"`);
+    return `${prefix}${newBody}}`;
+  });
+  await writeFile(filePath, content, 'utf-8');
+}
+
 export async function readText(filePath: string): Promise<string> {
   return readFile(filePath, 'utf-8');
 }

--- a/packages/bumpy/test/core/apply-release-plan.test.ts
+++ b/packages/bumpy/test/core/apply-release-plan.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { resolve } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { writeJson, readJson, readText, writeText, ensureDir, exists } from '../../src/utils/fs.ts';
@@ -227,6 +228,135 @@ describe('applyReleasePlan', () => {
     const appPkg = await readJson<Record<string, unknown>>(resolve(appDir, 'package.json'));
     const deps = appPkg.dependencies as Record<string, string>;
     expect(deps.core).toBe('workspace:^2.0.0');
+  });
+
+  test('preserves package.json formatting when bumping version', async () => {
+    // Write a package.json with custom formatting (inline arrays, tab indent, etc.)
+    const pkgDir = resolve(tmpDir, 'packages/pkg-a');
+    await ensureDir(pkgDir);
+    const originalContent = [
+      '{',
+      '\t"name": "pkg-a",',
+      '\t"version": "1.0.0",',
+      '\t"keywords": ["alpha", "beta", "gamma"],',
+      '\t"files": ["dist", "src"],',
+      '\t"exports": {',
+      '\t\t".": "./dist/index.js"',
+      '\t}',
+      '}',
+      '',
+    ].join('\n');
+    await writeFile(resolve(pkgDir, 'package.json'), originalContent, 'utf-8');
+
+    const packages = new Map<string, WorkspacePackage>();
+    packages.set('pkg-a', {
+      name: 'pkg-a',
+      version: '1.0.0',
+      dir: pkgDir,
+      relativeDir: 'packages/pkg-a',
+      packageJson: { name: 'pkg-a', version: '1.0.0' },
+      private: false,
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+
+    const changeset = makeChangeset('cs1', [{ name: 'pkg-a', type: 'minor' }], 'New feature');
+    const release = makeRelease('pkg-a', '1.1.0', {
+      type: 'minor',
+      oldVersion: '1.0.0',
+      changesets: ['cs1'],
+    });
+
+    await ensureDir(resolve(tmpDir, '.bumpy'));
+    await writeText(resolve(tmpDir, '.bumpy/cs1.md'), '---\n"pkg-a": minor\n---\n\nNew feature\n');
+
+    await applyReleasePlan(makeReleasePlan([release], [changeset]), packages, tmpDir, makeConfig());
+
+    const result = await readFile(resolve(pkgDir, 'package.json'), 'utf-8');
+    // Version should be updated
+    expect(result).toContain('"version": "1.1.0"');
+    // Inline arrays should stay inline
+    expect(result).toContain('"keywords": ["alpha", "beta", "gamma"]');
+    expect(result).toContain('"files": ["dist", "src"]');
+    // Tab indentation should be preserved
+    expect(result).toContain('\t"name"');
+    // Nested objects should keep their formatting
+    expect(result).toContain('\t\t".": "./dist/index.js"');
+  });
+
+  test('preserves package.json formatting when updating dependency ranges', async () => {
+    const coreDir = resolve(tmpDir, 'packages/core');
+    const appDir = resolve(tmpDir, 'packages/app');
+    await ensureDir(coreDir);
+    await ensureDir(appDir);
+
+    // Core has a simple package.json
+    await writeFile(resolve(coreDir, 'package.json'), '{\n  "name": "core",\n  "version": "1.0.0"\n}\n', 'utf-8');
+
+    // App has custom formatting with inline arrays and specific indentation
+    const appOriginal = [
+      '{',
+      '    "name": "app",',
+      '    "version": "1.0.0",',
+      '    "tags": ["web", "frontend"],',
+      '    "dependencies": {',
+      '        "core": "^1.0.0",',
+      '        "lodash": "^4.17.0"',
+      '    }',
+      '}',
+      '',
+    ].join('\n');
+    await writeFile(resolve(appDir, 'package.json'), appOriginal, 'utf-8');
+
+    const packages = new Map<string, WorkspacePackage>();
+    packages.set('core', {
+      name: 'core',
+      version: '1.0.0',
+      dir: coreDir,
+      relativeDir: 'packages/core',
+      packageJson: { name: 'core', version: '1.0.0' },
+      private: false,
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+    packages.set('app', {
+      name: 'app',
+      version: '1.0.0',
+      dir: appDir,
+      relativeDir: 'packages/app',
+      packageJson: { name: 'app', version: '1.0.0', dependencies: { core: '^1.0.0', lodash: '^4.17.0' } },
+      private: false,
+      dependencies: { core: '^1.0.0' },
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+
+    const changeset = makeChangeset('cs1', [{ name: 'core', type: 'major' }], 'Breaking');
+    const coreRelease = makeRelease('core', '2.0.0', { type: 'major', oldVersion: '1.0.0', changesets: ['cs1'] });
+    const appRelease = makeRelease('app', '1.0.1', { oldVersion: '1.0.0', isDependencyBump: true });
+
+    await ensureDir(resolve(tmpDir, '.bumpy'));
+    await writeText(resolve(tmpDir, '.bumpy/cs1.md'), '---\n"core": major\n---\n\nBreaking\n');
+
+    await applyReleasePlan(makeReleasePlan([coreRelease, appRelease], [changeset]), packages, tmpDir, makeConfig());
+
+    const result = await readFile(resolve(appDir, 'package.json'), 'utf-8');
+    // Version should be updated
+    expect(result).toContain('"version": "1.0.1"');
+    // Dependency range should be updated
+    expect(result).toContain('"core": "^2.0.0"');
+    // Inline arrays must remain inline
+    expect(result).toContain('"tags": ["web", "frontend"]');
+    // 4-space indentation must be preserved
+    expect(result).toContain('    "name"');
+    expect(result).toContain('        "core"');
+    // Unrelated dependencies should be untouched
+    expect(result).toContain('"lodash": "^4.17.0"');
   });
 
   test('deletes consumed changeset files', async () => {


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify` round-trip with targeted string replacements when bumping versions and updating dependency ranges in `package.json` files
- Prevents reformatting issues like inline arrays being expanded to multi-line, indentation style changes, and other unnecessary churn (matching a known pain point from changesets)
- Also applies the fix to workspace/catalog protocol resolution in the publish pipeline

## Test plan
- [x] Added test: preserves tab indentation, inline arrays, and nested object formatting through a version bump
- [x] Added test: preserves 4-space indentation, inline arrays, and unrelated dependencies through a dependency range update
- [x] All 157 existing tests continue to pass

🐸 Generated with [Claude Code](https://claude.com/claude-code)