### PR TITLE
Fix: replace Bun.CryptoHasher with node:crypto

### DIFF
--- a/.bumpy/fix-bun-runtime-dep.md
+++ b/.bumpy/fix-bun-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix "Bun is not defined" error in CI release command when running under Node.js by replacing `Bun.CryptoHasher` with `node:crypto`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
+      # Node.js is needed for npm publish (trusted publishing via OIDC)
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -8,6 +8,7 @@ import { assembleReleasePlan } from '../core/release-plan.ts';
 import { runArgs, runArgsAsync, tryRunArgs } from '../utils/shell.ts';
 import { randomName } from '../utils/names.ts';
 import { detectPackageManager } from '../utils/package-manager.ts';
+import { createHash } from 'node:crypto';
 import type { BumpyConfig, BumpFile, PackageManager, ReleasePlan, PlannedRelease } from '../types.ts';
 
 // ---- Validation helpers ----
@@ -468,11 +469,7 @@ function buildDiffLinks(pkgDir: string): string {
 }
 
 function sha256Hex(input: string): string {
-  const encoder = new TextEncoder();
-  // Bun supports crypto.subtle synchronously via Bun.CryptoHasher
-  const hasher = new Bun.CryptoHasher('sha256');
-  hasher.update(encoder.encode(input));
-  return hasher.digest('hex');
+  return createHash('sha256').update(input).digest('hex');
 }
 
 function formatVersionPrBody(plan: ReleasePlan, preamble: string, packageDirs: Map<string, string>): string {


### PR DESCRIPTION
## Summary
- Replace `Bun.CryptoHasher` in `ci.ts` with `node:crypto`'s `createHash`, which works in both Bun and Node.js runtimes
- Fixes "Bun is not defined" error when the CLI runs under Node.js (e.g. via `bunx` in the release workflow)
- Add clarifying comment for why `setup-node` is needed in the release workflow

## Test plan
- [x] Build succeeds
- [x] All 178 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)