### PR TITLE
Fix internalAuthors option being silently ignored

### DIFF
--- a/.bumpy/fix-internal-authors.md
+++ b/.bumpy/fix-internal-authors.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix `internalAuthors` option being ignored by the GitHub changelog formatter. The `loadFormatter` function matched the built-in "github" entry before reaching the options-aware path, so options like `internalAuthors` were silently dropped.

--- a/packages/bumpy/src/core/changelog.ts
+++ b/packages/bumpy/src/core/changelog.ts
@@ -74,7 +74,13 @@ const BUILTIN_FORMATTERS: Record<string, ChangelogFormatter | (() => Promise<Cha
 export async function loadFormatter(changelog: BumpyConfig['changelog'], rootDir: string): Promise<ChangelogFormatter> {
   const [name, options] = Array.isArray(changelog) ? changelog : [changelog, {}];
 
-  // Built-in formatter
+  // Built-in with options (e.g., ["github", { repo: "..." }])
+  if (name === 'github') {
+    const { createGithubFormatter } = await import('./changelog-github.ts');
+    return createGithubFormatter(options as import('./changelog-github.ts').GithubChangelogOptions);
+  }
+
+  // Built-in formatter (no options)
   if (typeof name === 'string' && BUILTIN_FORMATTERS[name]) {
     const builtin = BUILTIN_FORMATTERS[name];
     if (typeof builtin === 'function' && builtin.length === 0) {
@@ -82,12 +88,6 @@ export async function loadFormatter(changelog: BumpyConfig['changelog'], rootDir
       return (builtin as () => Promise<ChangelogFormatter>)();
     }
     return builtin as ChangelogFormatter;
-  }
-
-  // Built-in with options (e.g., ["github", { repo: "..." }])
-  if (name === 'github') {
-    const { createGithubFormatter } = await import('./changelog-github.ts');
-    return createGithubFormatter(options as import('./changelog-github.ts').GithubChangelogOptions);
   }
 
   // Custom module

--- a/packages/bumpy/test/core/changelog.test.ts
+++ b/packages/bumpy/test/core/changelog.test.ts
@@ -1,6 +1,12 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { makeRelease, makeBumpFile } from '../helpers.ts';
-import { defaultFormatter, generateChangelogEntry, prependToChangelog } from '../../src/core/changelog.ts';
+import { installShellMock, uninstallShellMock, addMockRule } from '../helpers-shell-mock.ts';
+import {
+  defaultFormatter,
+  generateChangelogEntry,
+  loadFormatter,
+  prependToChangelog,
+} from '../../src/core/changelog.ts';
 
 describe('defaultFormatter', () => {
   test('formats basic release with bump files', async () => {
@@ -152,5 +158,54 @@ describe('prependToChangelog', () => {
 
     expect(result).toContain('- Old entry');
     expect(result).toContain('- New entry');
+  });
+});
+
+describe('loadFormatter', () => {
+  beforeEach(() => {
+    installShellMock();
+    addMockRule({ match: 'gh repo view', response: 'dmno-dev/bumpy' });
+  });
+
+  afterEach(() => {
+    uninstallShellMock();
+  });
+
+  test('passes options through to github formatter', async () => {
+    addMockRule({ match: /^git log/, response: '' });
+
+    const formatter = await loadFormatter(
+      ['github', { internalAuthors: ['theoephraim'], repo: 'dmno-dev/bumpy' }],
+      '/tmp',
+    );
+    const release = makeRelease('pkg-a', '1.0.1', { bumpFiles: ['cs1'] });
+    const bumpFiles = [makeBumpFile('cs1', [{ name: 'pkg-a', type: 'patch' }], 'author: @theoephraim\nFixed it')];
+
+    const result = await formatter({ release, bumpFiles, date: '2026-04-14' });
+
+    expect(result).not.toContain('Thanks');
+  });
+
+  test('github formatter without options still works', async () => {
+    addMockRule({ match: /^git log/, response: '' });
+
+    const formatter = await loadFormatter('github', '/tmp');
+    const release = makeRelease('pkg-a', '1.0.1', { bumpFiles: ['cs1'] });
+    const bumpFiles = [makeBumpFile('cs1', [{ name: 'pkg-a', type: 'patch' }], 'author: @someone\nFixed it')];
+
+    const result = await formatter({ release, bumpFiles, date: '2026-04-14' });
+
+    expect(result).toContain('Thanks [@someone]');
+  });
+
+  test('loads default formatter by name', async () => {
+    const formatter = await loadFormatter('default', '/tmp');
+    const release = makeRelease('pkg-a', '1.0.0', { bumpFiles: ['cs1'] });
+    const bumpFiles = [makeBumpFile('cs1', [{ name: 'pkg-a', type: 'patch' }], 'A fix')];
+
+    const result = await formatter({ release, bumpFiles, date: '2026-04-14' });
+
+    expect(result).toContain('## 1.0.0');
+    expect(result).toContain('- A fix');
   });
 });


### PR DESCRIPTION
## Summary
- `loadFormatter` had a bug where the generic built-in formatter lookup matched `"github"` before the options-aware code path, so config like `["github", { "internalAuthors": [...] }]` silently dropped the options and created the formatter with defaults
- Reordered the branches so the `github`-specific path (which forwards options to `createGithubFormatter`) runs first
- Added `loadFormatter` tests covering options passthrough, bare `"github"` string, and default formatter

## Test plan
- [x] Existing tests pass (175 total)
- [ ] Verify changelogs generated by `bumpy ci release` no longer include "Thanks @..." for internal authors

🐸 Generated with [Claude Code](https://claude.com/claude-code)