### PR TITLE
Fix force-push guard comparing against HEAD instead of base branch

### DIFF
--- a/.bumpy/fix-force-push-guard.md
+++ b/.bumpy/fix-force-push-guard.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix force-push guard that was incorrectly comparing against HEAD instead of the configured base branch

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,3 +8,8 @@ pre-commit:
       glob: '*.{js,ts,tsx,jsx,json,css,md,yml,yaml}'
       run: bunx oxfmt {staged_files}
       stage_fixed: true
+
+pre-push:
+  jobs:
+    - name: bumpy-check
+      run: bunx @varlock/bumpy check

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -228,10 +228,9 @@ async function autoPublish(rootDir: string, config: BumpyConfig, tag?: string): 
  * When only the default `GITHUB_TOKEN` is available the push still succeeds,
  * but PR workflows won't be triggered automatically.
  */
-function pushWithToken(rootDir: string, branch: string): void {
+function pushWithToken(rootDir: string, branch: string, config: BumpyConfig): void {
   // Guard against misconfigured versionPr.branch pointing at the base branch
-  const baseBranch = tryRunArgs(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], { cwd: rootDir });
-  if (branch === baseBranch || branch === 'main' || branch === 'master') {
+  if (branch === config.baseBranch || branch === 'main' || branch === 'master') {
     throw new Error(`Refusing to force-push to "${branch}" — this looks like a base branch, not a version PR branch`);
   }
 
@@ -347,7 +346,7 @@ async function createVersionPr(
   const commitMsg = ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
   runArgs(['git', 'commit', '-F', '-'], { cwd: rootDir, input: commitMsg });
 
-  pushWithToken(rootDir, branch);
+  pushWithToken(rootDir, branch, config);
 
   // Create or update PR
   const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs);
@@ -377,7 +376,7 @@ async function createVersionPr(
       // `pull_request: synchronize` event is generated and CI workflows trigger.
       // (The initial push happened before the PR existed, and the PR creation
       // event from GITHUB_TOKEN doesn't trigger workflows.)
-      pushWithToken(rootDir, branch);
+      pushWithToken(rootDir, branch, config);
     }
   }
 

--- a/packages/bumpy/src/core/bump-file.ts
+++ b/packages/bumpy/src/core/bump-file.ts
@@ -16,8 +16,11 @@ const VALID_BUMP_TYPES = new Set<string>(['major', 'minor', 'patch', 'none']);
  */
 function validatePackageName(name: string): boolean {
   if (!name || name.length > 214) return false;
-  // disallow control chars, HTML/shell metacharacters, whitespace
-  if (/[\u0000-\u001f\u007f<>"'`&;|$(){}[\]\\!#%\s]/.test(name)) return false;
+  // disallow control chars
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(name)) return false;
+  // disallow HTML/shell metacharacters and whitespace
+  if (/[<>"'`&;|$(){}[\]\\!#%\s]/.test(name)) return false;
   // must not start with - (could be interpreted as a CLI flag)
   if (name.startsWith('-')) return false;
   return true;


### PR DESCRIPTION
## Summary

- The force-push safeguard added in #24 compared the push target against `HEAD`, but `pushWithToken` is called after checking out the version PR branch — so `HEAD === branch` always triggered the error
- Now compares against `config.baseBranch` instead, which is the actual base branch (e.g. `main`)

## Test plan

- [ ] Verify `bumpy ci release` creates/updates the version PR without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)