### PR TITLE
Fix git push auth: revert to URL rewriting, add token redaction

### DIFF
--- a/.bumpy/fix-git-push-auth.md
+++ b/.bumpy/fix-git-push-auth.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix git push auth: revert to URL rewriting approach and add token redaction on errors

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -239,17 +239,15 @@ function pushWithToken(rootDir: string, branch: string, config: BumpyConfig): vo
   const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
 
   if (token && repo) {
-    // Use an ephemeral `-c` flag to inject auth so the token never touches .git/config.
-    // GitHub accepts HTTP basic auth with "x-access-token" as the username.
-    const basicAuth = Buffer.from(`x-access-token:${token}`).toString('base64');
-    const extraHeaderKey = `http.${server}/.extraheader`;
-    const authHeader = `Authorization: basic ${basicAuth}`;
+    const authedUrl = `${server.replace('://', `://x-access-token:${token}@`)}/${repo}.git`;
+    const originalUrl = tryRunArgs(['git', 'remote', 'get-url', 'origin'], { cwd: rootDir });
 
     // `actions/checkout@v6` persists the default GITHUB_TOKEN in two ways:
     //   1. Direct http.<server>/.extraheader config
     //   2. includeIf.gitdir entries pointing to a credentials config file
     //      that also sets http.<server>/.extraheader
     // Both must be cleared for our custom token to be used.
+    const extraHeaderKey = `http.${server}/.extraheader`;
     const savedHeader = tryRunArgs(['git', 'config', '--local', extraHeaderKey], { cwd: rootDir });
 
     // Collect includeIf entries that point to credential config files
@@ -273,12 +271,19 @@ function pushWithToken(rootDir: string, branch: string, config: BumpyConfig): vo
       for (const entry of savedIncludeIfs) {
         tryRunArgs(['git', 'config', '--local', '--unset', entry.key], { cwd: rootDir });
       }
-      // Pass auth via ephemeral -c flag — never written to .git/config
-      runArgs(['git', '-c', `${extraHeaderKey}=${authHeader}`, 'push', '-u', 'origin', branch, '--force'], {
-        cwd: rootDir,
-      });
+      runArgs(['git', 'remote', 'set-url', 'origin', authedUrl], { cwd: rootDir });
+      try {
+        runArgs(['git', 'push', '-u', 'origin', branch, '--force'], { cwd: rootDir });
+      } catch (err) {
+        // Redact token from error messages to prevent leakage in CI logs
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(msg.replaceAll(token, '***'));
+      }
     } finally {
-      // Restore extraheader and includeIf entries cleared above
+      // Restore original URL, extraheader, and includeIf entries
+      if (originalUrl) {
+        runArgs(['git', 'remote', 'set-url', 'origin', originalUrl], { cwd: rootDir });
+      }
       if (savedHeader) {
         runArgs(['git', 'config', '--local', extraHeaderKey, savedHeader], { cwd: rootDir });
       }


### PR DESCRIPTION
## Summary

- The `-c http.extraheader` approach from #24 didn't work with `execFileSync` in CI, causing the push to fail and leaking the token in the error message
- Revert to the proven URL rewriting approach (temporarily set remote URL, restore in `finally`)
- Add token redaction: if the push fails, the token is scrubbed from the error before re-throwing

## Test plan

- [ ] Verify `bumpy ci release` successfully pushes the version PR branch
- [ ] Verify token is not exposed in error messages on push failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)