### PR TITLE
Fix git push auth: includeIf regex case mismatch

### DIFF
--- a/.bumpy/fix-includeif-case.md
+++ b/.bumpy/fix-includeif-case.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix git push auth failure caused by case-sensitive includeIf regex not matching lowercase keys from git config

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -251,7 +251,8 @@ function pushWithToken(rootDir: string, branch: string, config: BumpyConfig): vo
     const savedHeader = tryRunArgs(['git', 'config', '--local', extraHeaderKey], { cwd: rootDir });
 
     // Collect includeIf entries that point to credential config files
-    const includeIfRaw = tryRunArgs(['git', 'config', '--local', '--get-regexp', '^includeIf\\.gitdir:'], {
+    // git config --get-regexp outputs keys in lowercase, so match accordingly
+    const includeIfRaw = tryRunArgs(['git', 'config', '--local', '--get-regexp', '^includeif\\.gitdir:'], {
       cwd: rootDir,
     });
     const savedIncludeIfs: Array<{ key: string; value: string }> = [];


### PR DESCRIPTION
## Summary

- `git config --get-regexp` outputs keys in lowercase (`includeif.gitdir:...`), but the regex used `^includeIf\.gitdir:` (capital I/F) which never matched
- This meant `actions/checkout@v6` credential config files were never cleared, and their injected `GITHUB_TOKEN` auth header overrode the custom `BUMPY_GH_TOKEN` URL — causing the push to fail
- This was a latent bug in the original code, likely masked before `checkout@v6` started using `includeIf` credential files

## Test plan

- [ ] Verify `bumpy ci release` successfully pushes the version PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)