### PR TITLE
Fix check to only count bump files from current branch

### DIFF
--- a/.bumpy/fix-check-branch-filter.md
+++ b/.bumpy/fix-check-branch-filter.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix check command to only count bump files from current branch, and handle empty bump files correctly in both local and CI check

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -2,7 +2,7 @@ import { relative } from 'node:path';
 import { log, colorize } from '../utils/logger.ts';
 import { loadConfig } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
-import { readBumpFiles } from '../core/bump-file.ts';
+import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
 import { getChangedFiles } from '../core/git.ts';
 import type { WorkspacePackage } from '../types.ts';
 
@@ -14,23 +14,33 @@ import type { WorkspacePackage } from '../types.ts';
 export async function checkCommand(rootDir: string): Promise<void> {
   const config = await loadConfig(rootDir);
   const { packages } = await discoverWorkspace(rootDir, config);
-  const bumpFiles = await readBumpFiles(rootDir);
 
-  // Find which packages already have bump files
-  const coveredPackages = new Set<string>();
-  for (const bf of bumpFiles) {
-    for (const release of bf.releases) {
-      coveredPackages.add(release.name);
-    }
-  }
-
-  // Find which packages have changed on this branch vs base
+  // Find which files have changed on this branch vs base
   const baseBranch = config.baseBranch;
   const changedFiles = getChangedFiles(rootDir, baseBranch);
 
   if (changedFiles.length === 0) {
     log.info('No changed files detected.');
     return;
+  }
+
+  // Filter to only bump files added/modified on this branch
+  const allBumpFiles = await readBumpFiles(rootDir);
+  const { branchBumpFiles, branchBumpFileIds } = filterBranchBumpFiles(allBumpFiles, changedFiles);
+
+  // If a bump file was changed but didn't parse (empty bump file), the check passes
+  const hasEmptyBumpFile = branchBumpFileIds.size > branchBumpFiles.length;
+  if (hasEmptyBumpFile) {
+    log.success('Empty bump file found — no releases needed.');
+    return;
+  }
+
+  // Find which packages are covered by bump files on this branch
+  const coveredPackages = new Set<string>();
+  for (const bf of branchBumpFiles) {
+    for (const release of bf.releases) {
+      coveredPackages.add(release.name);
+    }
   }
 
   const changedPackages = findChangedPackages(changedFiles, packages, rootDir);

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -2,7 +2,7 @@ import { log, colorize } from '../utils/logger.ts';
 import { loadConfig } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { DependencyGraph } from '../core/dep-graph.ts';
-import { readBumpFiles } from '../core/bump-file.ts';
+import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
 import { getChangedFiles } from '../core/git.ts';
 import { assembleReleasePlan } from '../core/release-plan.ts';
 import { runArgs, runArgsAsync, tryRunArgs } from '../utils/shell.ts';
@@ -107,12 +107,22 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
 
   // Filter to only bump files added/modified in this PR
   const changedFiles = getChangedFiles(rootDir, config.baseBranch);
-  const prBumpFileIds = new Set(
-    changedFiles
-      .filter((f) => /^\.bumpy\/.*\.md$/.test(f) && !f.endsWith('README.md'))
-      .map((f) => f.replace(/^\.bumpy\//, '').replace(/\.md$/, '')),
+  const { branchBumpFiles: prBumpFiles, branchBumpFileIds: prBumpFileIds } = filterBranchBumpFiles(
+    allBumpFiles,
+    changedFiles,
   );
-  const prBumpFiles = allBumpFiles.filter((bf) => prBumpFileIds.has(bf.id));
+
+  // An empty bump file signals intentionally no releases needed
+  const hasEmptyBumpFile = prBumpFileIds.size > prBumpFiles.length;
+
+  if (hasEmptyBumpFile) {
+    log.success('Empty bump file found — no releases needed.');
+    if (shouldComment && prNumber) {
+      const prBranch = detectPrBranch(rootDir);
+      await postOrUpdatePrComment(prNumber, formatNoBumpFilesComment(prBranch, pm), rootDir, opts.patComments);
+    }
+    return;
+  }
 
   if (prBumpFiles.length === 0) {
     const msg = 'No bump files found in this PR.';

--- a/packages/bumpy/src/core/bump-file.ts
+++ b/packages/bumpy/src/core/bump-file.ts
@@ -172,3 +172,29 @@ function fileToId(filePath: string): string {
   const base = filePath.split('/').pop()!;
   return base.replace(/\.md$/, '');
 }
+
+/**
+ * Given a list of changed file paths (relative to root), extract the IDs
+ * of bump files that were added/modified. Shared by `check` and `ci check`.
+ */
+export function extractBumpFileIdsFromChangedFiles(changedFiles: string[]): Set<string> {
+  return new Set(
+    changedFiles
+      .filter((f) => /^\.bumpy\/.*\.md$/.test(f) && !f.endsWith('README.md'))
+      .map((f) => f.replace(/^\.bumpy\//, '').replace(/\.md$/, '')),
+  );
+}
+
+/**
+ * Filter bump files to only those added/modified on the current branch.
+ * Returns the filtered bump files and whether any changed bump file was
+ * empty (has no releases — signals intentionally no releases needed).
+ */
+export function filterBranchBumpFiles(
+  allBumpFiles: BumpFile[],
+  changedFiles: string[],
+): { branchBumpFiles: BumpFile[]; branchBumpFileIds: Set<string> } {
+  const branchBumpFileIds = extractBumpFileIdsFromChangedFiles(changedFiles);
+  const branchBumpFiles = allBumpFiles.filter((bf) => branchBumpFileIds.has(bf.id));
+  return { branchBumpFiles, branchBumpFileIds };
+}


### PR DESCRIPTION
## Summary
- `bumpy check` was counting **all** pending bump files in `.bumpy/`, so it would pass even if the current branch didn't add one. Now it filters to only bump files added/modified on the branch, matching `bumpy ci check` behavior.
- Extracted shared `filterBranchBumpFiles` helper in `bump-file.ts` used by both `check` and `ci check`
- Fixed empty bump file handling in both commands — empty bump files (no releases) are now properly detected and pass the check

## Test plan
- [ ] Push a branch with package changes but no bump file — `bumpy check` should fail
- [ ] Push a branch with package changes and a bump file — should pass
- [ ] Push a branch with an empty bump file — should pass with "no releases needed"
- [ ] Verify `bumpy ci check` still works correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)