### PR TITLE
Fix empty bump files not deleted during versioning

### DIFF
--- a/.bumpy/fix-delete-empty-bump-files.md
+++ b/.bumpy/fix-delete-empty-bump-files.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix empty bump files not being deleted during versioning

--- a/packages/bumpy/src/core/apply-release-plan.ts
+++ b/packages/bumpy/src/core/apply-release-plan.ts
@@ -1,7 +1,16 @@
 import { resolve } from 'node:path';
-import { readJson, readText, writeText, exists, updateJsonFields, updateJsonNestedField } from '../utils/fs.ts';
-import { deleteBumpFiles } from './bump-file.ts';
+import {
+  readJson,
+  readText,
+  writeText,
+  exists,
+  updateJsonFields,
+  updateJsonNestedField,
+  listFiles,
+  removeFile,
+} from '../utils/fs.ts';
 import { generateChangelogEntry, prependToChangelog, loadFormatter } from './changelog.ts';
+import { getBumpyDir } from './config.ts';
 import type { ReleasePlan, WorkspacePackage, BumpyConfig } from '../types.ts';
 
 /** Apply the release plan: bump versions, update changelogs, delete bump files */
@@ -50,9 +59,13 @@ export async function applyReleasePlan(
     await writeText(changelogPath, newContent);
   }
 
-  // 3. Delete consumed bump files
-  const bfIds = releasePlan.bumpFiles.map((bf) => bf.id);
-  await deleteBumpFiles(rootDir, bfIds);
+  // 3. Delete all bump files (including empty ones that aren't in the release plan)
+  const bumpyDir = getBumpyDir(rootDir);
+  const allBumpFiles = await listFiles(bumpyDir, '.md');
+  for (const file of allBumpFiles) {
+    if (file === 'README.md') continue;
+    await removeFile(resolve(bumpyDir, file));
+  }
 }
 
 /** Update a version range to include a new version, preserving the range prefix */

--- a/packages/bumpy/test/core/apply-release-plan.test.ts
+++ b/packages/bumpy/test/core/apply-release-plan.test.ts
@@ -391,4 +391,73 @@ describe('applyReleasePlan', () => {
 
     expect(await exists(csPath)).toBe(false);
   });
+
+  test('deletes empty bump files that are not in the release plan', async () => {
+    const pkgDir = await setupPackage('pkg-a', '1.0.0');
+
+    const packages = new Map<string, WorkspacePackage>();
+    packages.set('pkg-a', {
+      name: 'pkg-a',
+      version: '1.0.0',
+      dir: pkgDir,
+      relativeDir: 'packages/pkg-a',
+      packageJson: { name: 'pkg-a', version: '1.0.0' },
+      private: false,
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+
+    const bumpFile = makeBumpFile('real-bump', [{ name: 'pkg-a', type: 'patch' }], 'Fix');
+    const release = makeRelease('pkg-a', '1.0.1', {
+      oldVersion: '1.0.0',
+      bumpFiles: ['real-bump'],
+    });
+
+    await ensureDir(resolve(tmpDir, '.bumpy'));
+    const realPath = resolve(tmpDir, '.bumpy/real-bump.md');
+    const emptyPath = resolve(tmpDir, '.bumpy/empty-ci-setup.md');
+    await writeText(realPath, '---\n"pkg-a": patch\n---\n\nFix\n');
+    await writeText(emptyPath, '---\n---\n\n');
+    expect(await exists(emptyPath)).toBe(true);
+
+    await applyReleasePlan(makeReleasePlan([release], [bumpFile]), packages, tmpDir, makeConfig());
+
+    expect(await exists(realPath)).toBe(false);
+    expect(await exists(emptyPath)).toBe(false);
+  });
+
+  test('preserves README.md in .bumpy directory', async () => {
+    const pkgDir = await setupPackage('pkg-a', '1.0.0');
+
+    const packages = new Map<string, WorkspacePackage>();
+    packages.set('pkg-a', {
+      name: 'pkg-a',
+      version: '1.0.0',
+      dir: pkgDir,
+      relativeDir: 'packages/pkg-a',
+      packageJson: { name: 'pkg-a', version: '1.0.0' },
+      private: false,
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+
+    const bumpFile = makeBumpFile('cs1', [{ name: 'pkg-a', type: 'patch' }], 'Fix');
+    const release = makeRelease('pkg-a', '1.0.1', {
+      oldVersion: '1.0.0',
+      bumpFiles: ['cs1'],
+    });
+
+    await ensureDir(resolve(tmpDir, '.bumpy'));
+    await writeText(resolve(tmpDir, '.bumpy/cs1.md'), '---\n"pkg-a": patch\n---\n\nFix\n');
+    const readmePath = resolve(tmpDir, '.bumpy/README.md');
+    await writeText(readmePath, '# Bump files go here\n');
+
+    await applyReleasePlan(makeReleasePlan([release], [bumpFile]), packages, tmpDir, makeConfig());
+
+    expect(await exists(readmePath)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Empty bump files (those with no releases in frontmatter, e.g. from `bumpy add --empty`) were not being deleted during `bumpy version` because `parseBumpFile()` returns `null` for them, so they never appeared in the release plan
- Changed `applyReleasePlan` to delete all `.md` files from `.bumpy/` (except `README.md`) instead of only those referenced in the release plan
- Added tests for empty bump file deletion and README.md preservation

## Test plan
- [x] All 177 existing + new tests pass
- [ ] Verify in a real repo that `bumpy version` cleans up empty bump files

🤖 Generated with [Claude Code](https://claude.com/claude-code)