### PR TITLE
Generate bump files from all branch commits

### DIFF
--- a/.bumpy/generate-from-all-commits.md
+++ b/.bumpy/generate-from-all-commits.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Generate command now detects bumps from all commits, not just conventional commits.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All of this is automated via two simple GitHub Actions workflows (see [CI setup]
 - **Flexible package management** — include/exclude any package individually via per-package config, glob patterns, or `privatePackages` setting
 - **Non-interactive CLI** — `bumpy add` works fully non-interactively for CI/CD and AI-assisted development
 - **Aggregated GitHub releases** — optionally create a single consolidated release instead of one per package
-- **Conventional commits bridge** — `bumpy generate` auto-creates bump files from conventional commit messages
+- **Auto-generate from commits** — `bumpy generate` creates bump files from branch commits — works with any commit style, with enhanced detection for conventional commits
 - **Pluggable changelog formatters** — built-in `"default"` and `"github"` formatters, or write your own
 - **Zero runtime dependencies** — dependencies are minimal and bundled at release time
 
@@ -215,11 +215,11 @@ The skill teaches the AI to examine git changes, identify affected packages, cho
 
 ## Why files instead of conventional commits?
 
-Tools like semantic-release infer version bumps from commit messages (`feat:` → minor, `fix:` → patch). This works for simple projects but breaks down in monorepos — a single PR often touches multiple packages with different bump levels, squash merges lose per-commit metadata, and commit messages are a poor place to write user-facing changelog entries. Bump files are explicit, reviewable in the PR diff, and can describe changes in language meant for consumers rather than developers. If you prefer conventional commits, `bumpy generate` can bridge the gap by auto-creating bump files from commit history.
+Tools like semantic-release infer version bumps from commit messages (`feat:` → minor, `fix:` → patch). This works for simple projects but breaks down in monorepos — a single PR often touches multiple packages with different bump levels, squash merges lose per-commit metadata, and commit messages are a poor place to write user-facing changelog entries. Bump files are explicit, reviewable in the PR diff, and can describe changes in language meant for consumers rather than developers. If you prefer commit-based workflows, `bumpy generate` can bridge the gap by auto-creating bump files from your branch commits — it works with any commit style, not just conventional commits.
 
 ## Why not just use changesets?
 
-Bumpy is built as a successor to [@changesets/changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated — hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [DIFFERENCES_FROM_CHANGESETS.md](./DIFFERENCES_FROM_CHANGESETS.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
+Bumpy is built as a successor to [@changesets/changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated — hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [differences from changesets](docs/differences-from-changesets.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
 
 - **Sane dependency propagation** — changesets hardcodes aggressive behavior where a minor bump triggers a major bump on all peer dependents. Bumpy uses a [three-phase algorithm](docs/version-propagation.md) with sensible defaults and full configurability.
 - **Workspace protocol resolution** — changesets uses `npm publish` even in pnpm/yarn workspaces, so `workspace:^` and `catalog:` protocols are NOT resolved, resulting in broken published packages.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ bumpy ai setup --target cursor    # creates Cursor rule file
 bumpy ai setup --target codex     # creates Codex instruction file
 ```
 
-The skill teaches the AI to examine git changes, identify affected packages, choose bump levels, and run `bumpy add` with the right arguments.
+The skill teaches the AI to examine git changes, identify affected packages, choose bump levels, and create bump files with `bumpy add`. It also instructs the AI to keep existing bump files up to date as work continues on a branch — updating packages, bump levels, and summaries to reflect the final state of changes.
 
 ## Documentation
 

--- a/docs/bump-files.md
+++ b/docs/bump-files.md
@@ -65,19 +65,18 @@ Flags:
 - `--name <name>` — set the filename (auto-slugified). If omitted, a random name is generated.
 - `--empty` — create an empty bump file (marks a PR as intentionally having no releases)
 
-### From conventional commits
+### From branch commits
 
 ```bash
 bumpy generate
 ```
 
-Scans git history and auto-creates bump files from conventional commit messages:
+Scans commits on the current branch and auto-creates a bump file. Works with any commit style:
 
-- `feat:` → minor
-- `fix:`, `perf:`, `refactor:`, etc. → patch
-- `feat!:` or `BREAKING CHANGE:` → major
+- **Conventional commits** (`feat(scope): ...`) get bump levels from the commit type (`feat` → minor, `fix` → patch, `feat!` → major)
+- **All other commits** are mapped to packages via changed file paths, defaulting to `patch`
 
-Commit scopes are mapped to package names automatically.
+See [`bumpy generate`](cli.md#bumpy-generate) for full details.
 
 ## Empty bump files
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,27 +100,29 @@ No flags. No GitHub API needed.
 
 ## `bumpy generate`
 
-Auto-create bump files from conventional commit messages in git history.
+Auto-create bump files from commits on the current branch. Works with any commit style — conventional commits get enhanced bump-level detection, while all other commits are mapped to packages via changed file paths (defaulting to `patch`).
 
 ```bash
 bumpy generate
-bumpy generate --from v1.0.0
 bumpy generate --dry-run
+bumpy generate --from v1.0.0   # override: scan from a specific ref instead of branch base
 ```
 
-| Flag            | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| `--from <ref>`  | Git ref to scan from (default: auto-detect from last version tag) |
-| `--dry-run`     | Preview without creating files                                    |
-| `--name <name>` | Bump file filename                                                |
+| Flag            | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| `--from <ref>`  | Git ref to scan from (default: branch point from `baseBranch` in config) |
+| `--dry-run`     | Preview without creating files                                           |
+| `--name <name>` | Bump file filename                                                       |
 
-**Commit mapping:**
+**How commits are mapped:**
 
-- `feat:` → minor
-- `fix:`, `perf:`, `refactor:`, `docs:`, `style:`, `test:`, `build:`, `ci:`, `chore:` → patch
-- `feat!:` or `BREAKING CHANGE:` → major
+1. **Conventional commits** (`type(scope): description`) use the commit type for bump level and the scope to resolve to a package name:
+   - `feat:` → minor
+   - `fix:`, `perf:`, `refactor:`, `docs:`, `style:`, `test:`, `build:`, `ci:`, `chore:` → patch
+   - `feat!:` or `BREAKING CHANGE:` → major
+2. **All other commits** (including scopeless conventional commits) are mapped to packages by detecting which files changed in the commit and matching them to package directories. These default to `patch`.
 
-Commit scopes (e.g., `feat(core):`) are mapped to package names automatically.
+When multiple commits affect the same package, the highest bump level wins.
 
 ## `bumpy ci check`
 

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -125,9 +125,9 @@ Bumpy includes the release date in every changelog heading by default.
 
 - (Previously listed under Planned)
 
-### Conventional commits bridge
+### Auto-generate from commits
 
-`bumpy generate` scans git history and auto-generates bump files from conventional commits (`feat(scope): ...` → minor, `fix(scope): ...` → patch, `feat!(scope): ...` → major). Scope is mapped to package names automatically. Not a replacement for explicit bump files — a bridge for teams migrating from semantic-release, or a convenience when you want both.
+`bumpy generate` scans commits on the current branch and auto-creates bump files. It works with any commit style — conventional commits get enhanced bump-level detection (`feat` → minor, `fix` → patch, `feat!` → major), while all other commits are mapped to packages via changed file paths (defaulting to `patch`). Not a replacement for explicit bump files — a bridge for teams migrating from semantic-release, or a convenience when you want both.
 
 - [changesets#862](https://github.com/changesets/changesets/issues/862) — conventional commits integration (70 thumbs-up, 21 comments)
 

--- a/packages/bumpy/skills/add-change/SKILL.md
+++ b/packages/bumpy/skills/add-change/SKILL.md
@@ -47,11 +47,16 @@ Use `none` in a bump file to suppress a bump on a package that would otherwise b
 
 ### 4. Write a clear summary
 
-Write a concise summary (1-3 sentences) describing **what** changed and **why**. This becomes the CHANGELOG entry. Good summaries:
+Write a concise summary for the CHANGELOG entry. Keep it short — ideally a single sentence, at most two. Good summaries:
 
 - Start with a verb: "Added...", "Fixed...", "Refactored..."
 - Focus on user-facing impact, not implementation details
 - Are specific enough to be useful months later
+- Avoid filler, jargon, or restating the bump level
+- Don't list every file changed — describe the logical change
+
+Bad: "Updated the authentication module to fix an issue where the token refresh mechanism was not properly handling expired refresh tokens, causing silent failures in the auth flow."
+Good: "Fixed token refresh failing silently on expired refresh tokens."
 
 ### 5. Create the bump file
 

--- a/packages/bumpy/skills/add-change/SKILL.md
+++ b/packages/bumpy/skills/add-change/SKILL.md
@@ -58,9 +58,11 @@ Write a concise summary for the CHANGELOG entry. Keep it short — ideally a sin
 Bad: "Updated the authentication module to fix an issue where the token refresh mechanism was not properly handling expired refresh tokens, causing silent failures in the auth flow."
 Good: "Fixed token refresh failing silently on expired refresh tokens."
 
-### 5. Create the bump file
+### 5. Create or update the bump file
 
-Use the non-interactive CLI:
+Check if there are already bump files on this branch (from step 1's `bumpy status`). If one exists that covers the same logical change, **update it in place** by editing the `.bumpy/<name>.md` file directly — adjust the package list, bump levels, and summary to reflect the current state of the branch. Don't create a new bump file for every incremental change on the same branch.
+
+If no relevant bump file exists yet, create one with the non-interactive CLI:
 
 ```bash
 bumpy add \
@@ -107,3 +109,4 @@ EOF
 - If the user hasn't made any changes yet, ask what they're planning to change
 - If the change doesn't affect any publishable packages (e.g., only root config files), suggest using `bumpy add --empty` to satisfy CI checks
 - One bump file per logical change — don't combine unrelated changes
+- **Keep bump files up to date** — as work continues on a branch, the bump file should reflect the final state of all changes, not just the first commit. If packages were added/removed or the bump level changed (e.g., a patch fix grew into a minor feature), update the existing bump file accordingly

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -187,7 +187,7 @@ function printHelp() {
   Commands:
     init                    Initialize .bumpy/ directory
     add                     Create a new bump file
-    generate                Generate bump file from conventional commits
+    generate                Generate bump file from branch commits
     status                  Show pending releases
     check                   Verify changed packages have bump files (for pre-push hooks)
     version                 Apply bump files and bump versions
@@ -205,7 +205,7 @@ function printHelp() {
     --empty                 Create an empty bump file
 
   Generate options:
-    --from <ref>            Git ref to scan from (default: last version tag)
+    --from <ref>            Git ref to scan from (default: branch point from baseBranch)
     --dry-run               Preview without creating a bump file
     --name <name>           Bump file filename
 

--- a/packages/bumpy/src/commands/generate.ts
+++ b/packages/bumpy/src/commands/generate.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path';
 import { log, colorize } from '../utils/logger.ts';
 import { tryRunArgs } from '../utils/shell.ts';
 import { loadConfig } from '../core/config.ts';
@@ -6,10 +7,11 @@ import { writeBumpFile } from '../core/bump-file.ts';
 import { getBumpyDir } from '../core/config.ts';
 import { ensureDir } from '../utils/fs.ts';
 import { slugify, randomName } from '../utils/names.ts';
+import { getBranchCommits, getFilesChangedInCommit } from '../core/git.ts';
 import type { BumpType, BumpTypeWithNone, BumpyConfig, BumpFileRelease, WorkspacePackage } from '../types.ts';
 
 interface GenerateOptions {
-  from?: string; // git ref to start from (default: auto-detect last version tag)
+  from?: string; // git ref to start from (default: branch base)
   dryRun?: boolean;
   name?: string;
 }
@@ -40,74 +42,95 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
   const config = await loadConfig(rootDir);
   const packages = await discoverPackages(rootDir, config);
 
-  // Determine the starting ref
-  const from = opts.from || findLastVersionTag(rootDir);
-  if (!from) {
-    log.error('Could not detect last version tag. Use --from <ref> to specify.');
-    process.exit(1);
+  // Get commits — either from explicit ref or from branch divergence point
+  let commits: { hash: string; subject: string; body: string }[];
+
+  if (opts.from) {
+    log.step(`Scanning commits from ${colorize(opts.from, 'cyan')}...`);
+    const rawLog = tryRunArgs(['git', 'log', `${opts.from}..HEAD`, '--format=%H%n%s%n%b%n---END---'], { cwd: rootDir });
+    if (!rawLog) {
+      log.info('No commits found since ' + opts.from);
+      return;
+    }
+    commits = parseGitLog(rawLog);
+  } else {
+    log.step(`Scanning commits on this branch (vs ${colorize(config.baseBranch, 'cyan')})...`);
+    commits = getBranchCommits(rootDir, config.baseBranch);
   }
 
-  log.step(`Scanning commits from ${colorize(from, 'cyan')}...`);
-
-  // Get commits since ref
-  const rawLog = tryRunArgs(['git', 'log', `${from}..HEAD`, '--format=%H%n%s%n%b%n---END---'], { cwd: rootDir });
-
-  if (!rawLog) {
-    log.info('No commits found since ' + from);
+  if (commits.length === 0) {
+    log.info('No commits found on this branch.');
     return;
   }
 
-  const commits = parseGitLog(rawLog);
-  const conventional = commits.map(parseConventionalCommit).filter((c): c is ConventionalCommit => c !== null);
+  log.dim(`  Found ${commits.length} commit(s)`);
 
-  if (conventional.length === 0) {
-    log.info('No conventional commits found. Commits must follow the format: type(scope): description');
-    return;
-  }
-
-  log.dim(`  Found ${conventional.length} conventional commit(s)`);
-
-  // Build scope → package name mapping
+  // Build scope → package name mapping for CC resolution
   const scopeMap = buildScopeMap(packages, config);
 
-  // Collect releases
+  // Collect releases from all commits
   const releaseMap = new Map<string, { type: BumpType; messages: string[] }>();
 
-  for (const commit of conventional) {
-    const bump: BumpType = commit.breaking ? 'major' : BUMP_MAP[commit.type] || 'patch';
+  let ccCount = 0;
+  let fileBasedCount = 0;
 
-    // Resolve scope to package name
-    let pkgNames: string[] = [];
-    if (commit.scope) {
-      const resolved = resolveScope(commit.scope, scopeMap, packages);
-      if (resolved.length > 0) {
-        pkgNames = resolved;
-      } else {
-        log.dim(`  Skipping: unknown scope "${commit.scope}" in: ${commit.description}`);
+  for (const commit of commits) {
+    const cc = parseConventionalCommit(commit);
+
+    if (cc) {
+      // Conventional commit — use type/scope for bump level
+      ccCount++;
+      const bump: BumpType = cc.breaking ? 'major' : BUMP_MAP[cc.type] || 'patch';
+
+      let pkgNames: string[] = [];
+      if (cc.scope) {
+        const resolved = resolveScope(cc.scope, scopeMap, packages);
+        if (resolved.length > 0) {
+          pkgNames = resolved;
+        }
+        // If scope didn't resolve, fall through to file-based detection below
+      }
+
+      if (pkgNames.length > 0) {
+        for (const name of pkgNames) {
+          mergeRelease(releaseMap, name, bump, cc.description);
+        }
         continue;
       }
-    } else {
-      // No scope — skip (we're doing scope-based only for now)
-      log.dim(`  Skipping (no scope): ${commit.type}: ${commit.description}`);
-      continue;
-    }
 
-    for (const name of pkgNames) {
-      const existing = releaseMap.get(name);
-      if (existing) {
-        // Upgrade bump if higher
-        if (bumpPriority(bump) > bumpPriority(existing.type)) {
-          existing.type = bump;
+      // CC commit but scope didn't resolve (or no scope) — use file-based detection
+      // with the CC-derived bump level
+      const files = getFilesChangedInCommit(commit.hash, { cwd: rootDir });
+      const touchedPkgs = mapFilesToPackages(files, packages, rootDir);
+
+      if (touchedPkgs.length > 0) {
+        for (const name of touchedPkgs) {
+          mergeRelease(releaseMap, name, bump, cc.description);
         }
-        existing.messages.push(commit.description);
       } else {
-        releaseMap.set(name, { type: bump, messages: [commit.description] });
+        log.dim(`  Skipping CC (no matching packages): ${cc.type}: ${cc.description}`);
+      }
+    } else {
+      // Non-conventional commit — use file paths to detect packages, default to patch
+      const files = getFilesChangedInCommit(commit.hash, { cwd: rootDir });
+      const touchedPkgs = mapFilesToPackages(files, packages, rootDir);
+
+      if (touchedPkgs.length > 0) {
+        fileBasedCount++;
+        for (const name of touchedPkgs) {
+          mergeRelease(releaseMap, name, 'patch', commit.subject);
+        }
+      } else {
+        log.dim(`  Skipping (no matching packages): ${commit.subject}`);
       }
     }
   }
 
+  if (ccCount > 0) log.dim(`  ${ccCount} conventional commit(s)`);
+  if (fileBasedCount > 0) log.dim(`  ${fileBasedCount} commit(s) detected via changed files`);
+
   if (releaseMap.size === 0) {
-    log.info('No package bumps detected from conventional commits.');
+    log.info('No package bumps detected from commits.');
     return;
   }
 
@@ -147,6 +170,38 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
   for (const r of releases) {
     log.dim(`  ${r.name}: ${r.type}`);
   }
+}
+
+/** Merge a bump into the release map, keeping the highest bump level */
+function mergeRelease(
+  releaseMap: Map<string, { type: BumpType; messages: string[] }>,
+  name: string,
+  bump: BumpType,
+  message: string,
+): void {
+  const existing = releaseMap.get(name);
+  if (existing) {
+    if (bumpPriority(bump) > bumpPriority(existing.type)) {
+      existing.type = bump;
+    }
+    existing.messages.push(message);
+  } else {
+    releaseMap.set(name, { type: bump, messages: [message] });
+  }
+}
+
+/** Map file paths to package names based on directory containment */
+function mapFilesToPackages(files: string[], packages: Map<string, WorkspacePackage>, rootDir: string): string[] {
+  const matched = new Set<string>();
+  for (const file of files) {
+    for (const [name, pkg] of packages) {
+      const pkgRelDir = relative(rootDir, pkg.dir);
+      if (file.startsWith(pkgRelDir + '/')) {
+        matched.add(name);
+      }
+    }
+  }
+  return [...matched];
 }
 
 /** Parse raw git log output into individual commits */
@@ -234,13 +289,4 @@ function resolveScope(
 
 function bumpPriority(type: BumpType): number {
   return type === 'major' ? 2 : type === 'minor' ? 1 : 0;
-}
-
-/** Find the most recent version tag in the repo */
-function findLastVersionTag(rootDir: string): string | null {
-  // Look for tags matching common patterns: v1.2.3, pkg@1.2.3, etc.
-  const tag =
-    tryRunArgs(['git', 'describe', '--tags', '--abbrev=0', '--match', 'v*'], { cwd: rootDir }) ||
-    tryRunArgs(['git', 'describe', '--tags', '--abbrev=0', '--match', '*@*'], { cwd: rootDir });
-  return tag || null;
 }

--- a/packages/bumpy/src/commands/init.ts
+++ b/packages/bumpy/src/commands/init.ts
@@ -23,7 +23,7 @@ export async function initCommand(rootDir: string): Promise<void> {
   // Write a README explaining the directory
   await writeText(
     resolve(bumpyDir, 'README.md'),
-    `# 🐸 Bumpy\n\nThis directory is used by [bumpy](${__BUMPY_WEBSITE_URL__}) to manage versioning.\n\nBump files (\`.md\`) in this directory describe pending version bumps.\nRun \`bumpy add\` to create a new bump file.\n`,
+    `# 🐸 Bumpy\n\nThis directory is used by [bumpy](${__BUMPY_WEBSITE_URL__}) to manage versioning.\n\nBump files (\`.md\`) in this directory describe pending version bumps.\nRun \`bumpy add\` to create one interactively, or \`bumpy generate\` to auto-create from branch commits.\n`,
   );
 
   log.success('Initialized .bumpy/ directory');

--- a/packages/bumpy/src/core/git.ts
+++ b/packages/bumpy/src/core/git.ts
@@ -54,6 +54,43 @@ export function getChangedFiles(rootDir: string, baseBranch: string): string[] {
   return diff.split('\n').filter(Boolean);
 }
 
+/** Get commits on the current branch since it diverged from baseBranch */
+export function getBranchCommits(
+  rootDir: string,
+  baseBranch: string,
+): { hash: string; subject: string; body: string }[] {
+  // Ensure we have the base branch ref
+  if (!tryRunArgs(['git', 'rev-parse', '--verify', `origin/${baseBranch}`], { cwd: rootDir })) {
+    tryRunArgs(['git', 'fetch', 'origin', baseBranch, '--depth=1'], { cwd: rootDir });
+  }
+
+  const mergeBase = tryRunArgs(['git', 'merge-base', 'HEAD', `origin/${baseBranch}`], { cwd: rootDir });
+  const ref = mergeBase || `origin/${baseBranch}`;
+
+  const rawLog = tryRunArgs(['git', 'log', `${ref}..HEAD`, '--format=%H%n%s%n%b%n---END---'], { cwd: rootDir });
+  if (!rawLog) return [];
+
+  const commits: { hash: string; subject: string; body: string }[] = [];
+  const entries = rawLog.split('---END---').filter((e) => e.trim());
+  for (const entry of entries) {
+    const lines = entry.trim().split('\n');
+    if (lines.length < 2) continue;
+    commits.push({
+      hash: lines[0]!.trim(),
+      subject: lines[1]!.trim(),
+      body: lines.slice(2).join('\n').trim(),
+    });
+  }
+  return commits;
+}
+
+/** Get files changed in a specific commit */
+export function getFilesChangedInCommit(hash: string, opts?: { cwd?: string }): string[] {
+  const result = tryRunArgs(['git', 'diff-tree', '--no-commit-id', '--name-only', '-r', hash], opts);
+  if (!result) return [];
+  return result.split('\n').filter(Boolean);
+}
+
 /** Get all tags matching a pattern */
 export function listTags(pattern: string, opts?: { cwd?: string }): string[] {
   const result = tryRunArgs(['git', 'tag', '-l', pattern], opts);


### PR DESCRIPTION
## Summary
- `bumpy generate` now scans all commits on the current branch (vs baseBranch), not just from the last version tag
- Non-conventional commits are mapped to packages via file paths and default to `patch` bumps
- CC commits still get enhanced bump-level inference; scopeless CC commits now also fall back to file-path detection
- AI skill updated with guidance for writing concise changelog summaries

## Test plan
- [x] All 175 existing tests pass
- [ ] Test `bumpy generate --dry-run` on a branch with mixed CC and non-CC commits
- [ ] Test `bumpy generate --from <ref>` override still works
- [ ] Verify non-CC commits correctly map to packages via file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)