### PR TITLE
Add JSON schema and enhance config options

### DIFF
--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../packages/bumpy/config-schema.json",
   "baseBranch": "main",
   "changelog": ["github", { "internalAuthors": ["theoephraim", "philmillman"] }]
 }

--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../packages/bumpy/config-schema.json",
   "baseBranch": "main",
-  "changelog": ["github", { "internalAuthors": ["theoephraim", "philmillman"] }]
+  "changelog": ["github", { "internalAuthors": ["theoephraim", "philmillman"] }],
+  "changedFilePatterns": ["src/**", "package.json", "tsconfig.json", "tsdown.config.ts"]
 }

--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -2,5 +2,5 @@
   "$schema": "../packages/bumpy/config-schema.json",
   "baseBranch": "main",
   "changelog": ["github", { "internalAuthors": ["theoephraim", "philmillman"] }],
-  "changedFilePatterns": ["src/**", "package.json", "tsconfig.json", "tsdown.config.ts"]
+  "changedFilePatterns": ["src/**", "skills/**", "package.json", "tsconfig.json", "tsdown.config.ts"]
 }

--- a/.bumpy/json-schema-and-config.md
+++ b/.bumpy/json-schema-and-config.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Add published JSON schema for config file with editor autocomplete/validation. New config options: `changedFilePatterns` (root + per-package) for filtering which file changes trigger package detection, `commit` object form for custom commit messages, and `changelog: false` to disable changelog generation.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/bumpy": {
       "name": "@varlock/bumpy",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "bin": {
         "bumpy": "./dist/cli.mjs",
       },
@@ -22,9 +22,11 @@
         "@clack/prompts": "^1.2.0",
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
+        "@types/picomatch": "^4.0.3",
         "@types/semver": "^7.7.0",
         "js-yaml": "^4.1.0",
         "picocolors": "^1.1.1",
+        "picomatch": "^4.0.4",
         "semver": "^7.7.2",
         "tsdown": "catalog:",
       },
@@ -192,6 +194,8 @@
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Bumpy is configured via `.bumpy/_config.json`, created by `bumpy init`. Per-pack
 | `updateInternalDependencies` | `"patch" \| "minor" \| "out-of-range"` | `"out-of-range"`                 | When to update internal dependency version ranges                                                |
 | `dependencyBumpRules`        | `object`                               | see below                        | Controls how bumps propagate through dependency types                                            |
 | `aggregateRelease`           | `boolean \| { enabled, title }`        | `false`                          | Create a single GitHub release instead of one per package                                        |
-| `commit`                     | `boolean \| object`                    | `false`                          | Auto-commit after `bumpy version` (see below)                                                    |
+| `versionCommitMessage`       | `string \| object`                     | —                                | Customize the version commit message (see below)                                                 |
 | `changedFilePatterns`        | `string[]`                             | `["**"]`                         | Glob patterns to filter which changed files count toward marking a package as changed            |
 | `publish`                    | `object`                               | see below                        | Publishing pipeline config                                                                       |
 | `gitUser`                    | `{ name, email }`                      | bumpy-bot                        | Git identity for CI commits                                                                      |
@@ -47,14 +47,15 @@ Set a dependency type to `false` to disable propagation entirely.
 
 See [version-propagation.md](version-propagation.md) for the full propagation algorithm.
 
-### Commit config
+### Version commit message
 
-Controls whether `bumpy version` auto-commits changes:
+Customize the commit message used when versioning — both by `bumpy version --commit` and CI commands. Omit to use the default ("Version packages" + list of releases).
 
-- `false` — don't commit (default)
-- `true` — commit with the default message ("Version packages" + list of releases)
-- `{ message: "..." }` — commit with a static custom message
-- `{ generateFn: "./path.ts" }` — commit with a dynamically generated message. The module should export a function that receives the release plan and returns a string.
+- `"My release"` — static commit message string
+- `{ message: "..." }` — static commit message
+- `{ generateFn: "./path.ts" }` — dynamically generated message. The module should export a function that receives the release plan and returns a string.
+
+To auto-commit locally, pass the `--commit` flag: `bumpy version --commit`. CI commands always commit and push automatically.
 
 ### Publishing config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,18 +86,18 @@ Per-package settings can be defined in two places:
 
 `package.json` settings take precedence over global config.
 
-| Option                | Type                       | Description                                                             |
-| --------------------- | -------------------------- | ----------------------------------------------------------------------- |
-| `managed`             | `boolean`                  | Opt this package in or out of versioning                                |
-| `access`              | `"public" \| "restricted"` | Override the global access level                                        |
-| `publishCommand`      | `string \| string[]`       | Custom command(s) to publish this package (replaces npm publish)        |
-| `buildCommand`        | `string`                   | Command to run before publishing                                        |
-| `registry`            | `string`                   | Custom npm registry URL                                                 |
-| `skipNpmPublish`      | `boolean`                  | Don't publish to npm (still creates git tags)                           |
-| `checkPublished`      | `string`                   | Custom command that outputs the currently published version             |
-| `changedFilePatterns` | `string[]`                 | Glob patterns for changed-file detection (overrides root setting)       |
-| `dependencyBumpRules` | `object`                   | Per-package override for dependency propagation rules                   |
-| `cascadeTo`           | `object`                   | Explicit cascade targets — glob pattern mapped to `{ trigger, bumpAs }` |
+| Option                | Type                       | Description                                                                  |
+| --------------------- | -------------------------- | ---------------------------------------------------------------------------- |
+| `managed`             | `boolean`                  | Opt this package in or out of versioning                                     |
+| `access`              | `"public" \| "restricted"` | Override the global access level                                             |
+| `publishCommand`      | `string \| string[]`       | Custom command(s) to publish this package (replaces npm publish)             |
+| `buildCommand`        | `string`                   | Command to run before publishing                                             |
+| `registry`            | `string`                   | Custom npm registry URL                                                      |
+| `skipNpmPublish`      | `boolean`                  | Don't publish to npm (still creates git tags)                                |
+| `checkPublished`      | `string`                   | Custom command that outputs the currently published version                  |
+| `changedFilePatterns` | `string[]`                 | Glob patterns for changed-file detection (replaces root setting, not merged) |
+| `dependencyBumpRules` | `object`                   | Per-package override for dependency propagation rules                        |
+| `cascadeTo`           | `object`                   | Explicit cascade targets — glob pattern mapped to `{ trigger, bumpAs }`      |
 
 ### Custom commands and `allowCustomCommands`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Bumpy is configured via `.bumpy/_config.json`, created by `bumpy init`. Per-pack
 | `updateInternalDependencies` | `"patch" \| "minor" \| "out-of-range"` | `"out-of-range"`                 | When to update internal dependency version ranges                                                |
 | `dependencyBumpRules`        | `object`                               | see below                        | Controls how bumps propagate through dependency types                                            |
 | `aggregateRelease`           | `boolean \| { enabled, title }`        | `false`                          | Create a single GitHub release instead of one per package                                        |
-| `versionCommitMessage`       | `string \| object`                     | —                                | Customize the version commit message (see below)                                                 |
+| `versionCommitMessage`       | `string`                               | —                                | Customize the version commit message (see below)                                                 |
 | `changedFilePatterns`        | `string[]`                             | `["**"]`                         | Glob patterns to filter which changed files count toward marking a package as changed            |
 | `publish`                    | `object`                               | see below                        | Publishing pipeline config                                                                       |
 | `gitUser`                    | `{ name, email }`                      | bumpy-bot                        | Git identity for CI commits                                                                      |
@@ -52,8 +52,7 @@ See [version-propagation.md](version-propagation.md) for the full propagation al
 Customize the commit message used when versioning — both by `bumpy version --commit` and CI commands. Omit to use the default ("Version packages" + list of releases).
 
 - `"My release"` — static commit message string
-- `{ message: "..." }` — static commit message
-- `{ generateFn: "./path.ts" }` — dynamically generated message. The module should export a function that receives the release plan and returns a string.
+- `"./scripts/commit-msg.ts"` — path to a module (starts with `./` or `../`) that exports a function receiving the release plan and returning a message string
 
 To auto-commit locally, pass the `--commit` flag: `bumpy version --commit`. CI commands always commit and push automatically.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,25 +4,26 @@ Bumpy is configured via `.bumpy/_config.json`, created by `bumpy init`. Per-pack
 
 ## Global config (`.bumpy/_config.json`)
 
-| Option                       | Type                                   | Default                          | Description                                                                         |
-| ---------------------------- | -------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| `baseBranch`                 | `string`                               | `"main"`                         | Branch used for release comparisons                                                 |
-| `access`                     | `"public" \| "restricted"`             | `"public"`                       | Default npm publish access level                                                    |
-| `changelog`                  | `string \| [string, options]`          | `"default"`                      | Changelog formatter — `"default"`, `"github"`, or path to a custom formatter        |
-| `fixed`                      | `string[][]`                           | `[]`                             | Package groups that always bump together to the same version                        |
-| `linked`                     | `string[][]`                           | `[]`                             | Package groups that share the highest bump level                                    |
-| `ignore`                     | `string[]`                             | `[]`                             | Package name globs to exclude from versioning                                       |
-| `include`                    | `string[]`                             | `[]`                             | Package name globs to explicitly include (overrides `ignore` and `privatePackages`) |
-| `privatePackages`            | `{ version, tag }`                     | `{ version: false, tag: false }` | Whether to version and/or create git tags for private packages                      |
-| `updateInternalDependencies` | `"patch" \| "minor" \| "out-of-range"` | `"out-of-range"`                 | When to update internal dependency version ranges                                   |
-| `dependencyBumpRules`        | `object`                               | see below                        | Controls how bumps propagate through dependency types                               |
-| `aggregateRelease`           | `boolean \| { enabled, title }`        | `false`                          | Create a single GitHub release instead of one per package                           |
-| `commit`                     | `boolean`                              | `false`                          | Auto-commit changes after `bumpy version`                                           |
-| `publish`                    | `object`                               | see below                        | Publishing pipeline config                                                          |
-| `gitUser`                    | `{ name, email }`                      | bumpy-bot                        | Git identity for CI commits                                                         |
-| `versionPr`                  | `{ title, branch, preamble }`          | see below                        | Customize the version PR                                                            |
-| `allowCustomCommands`        | `boolean \| string[]`                  | `false`                          | Allow per-package custom commands from `package.json` (see below)                   |
-| `packages`                   | `object`                               | `{}`                             | Per-package config overrides (keyed by package name)                                |
+| Option                       | Type                                   | Default                          | Description                                                                                      |
+| ---------------------------- | -------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `baseBranch`                 | `string`                               | `"main"`                         | Branch used for release comparisons                                                              |
+| `access`                     | `"public" \| "restricted"`             | `"public"`                       | Default npm publish access level                                                                 |
+| `changelog`                  | `false \| string \| [string, options]` | `"default"`                      | Changelog formatter — `"default"`, `"github"`, path to a custom formatter, or `false` to disable |
+| `fixed`                      | `string[][]`                           | `[]`                             | Package groups that always bump together to the same version                                     |
+| `linked`                     | `string[][]`                           | `[]`                             | Package groups that share the highest bump level                                                 |
+| `ignore`                     | `string[]`                             | `[]`                             | Package name globs to exclude from versioning                                                    |
+| `include`                    | `string[]`                             | `[]`                             | Package name globs to explicitly include (overrides `ignore` and `privatePackages`)              |
+| `privatePackages`            | `{ version, tag }`                     | `{ version: false, tag: false }` | Whether to version and/or create git tags for private packages                                   |
+| `updateInternalDependencies` | `"patch" \| "minor" \| "out-of-range"` | `"out-of-range"`                 | When to update internal dependency version ranges                                                |
+| `dependencyBumpRules`        | `object`                               | see below                        | Controls how bumps propagate through dependency types                                            |
+| `aggregateRelease`           | `boolean \| { enabled, title }`        | `false`                          | Create a single GitHub release instead of one per package                                        |
+| `commit`                     | `boolean \| object`                    | `false`                          | Auto-commit after `bumpy version` (see below)                                                    |
+| `changedFilePatterns`        | `string[]`                             | `["**"]`                         | Glob patterns to filter which changed files count toward marking a package as changed            |
+| `publish`                    | `object`                               | see below                        | Publishing pipeline config                                                                       |
+| `gitUser`                    | `{ name, email }`                      | bumpy-bot                        | Git identity for CI commits                                                                      |
+| `versionPr`                  | `{ title, branch, preamble }`          | see below                        | Customize the version PR                                                                         |
+| `allowCustomCommands`        | `boolean \| string[]`                  | `false`                          | Allow per-package custom commands from `package.json` (see below)                                |
+| `packages`                   | `object`                               | `{}`                             | Per-package config overrides (keyed by package name)                                             |
 
 ### Dependency bump rules
 
@@ -45,6 +46,15 @@ Set a dependency type to `false` to disable propagation entirely.
 | `optionalDependencies` | `minor` | `patch`  |
 
 See [version-propagation.md](version-propagation.md) for the full propagation algorithm.
+
+### Commit config
+
+Controls whether `bumpy version` auto-commits changes:
+
+- `false` — don't commit (default)
+- `true` — commit with the default message ("Version packages" + list of releases)
+- `{ message: "..." }` — commit with a static custom message
+- `{ generateFn: "./path.ts" }` — commit with a dynamically generated message. The module should export a function that receives the release plan and returns a string.
 
 ### Publishing config
 
@@ -85,6 +95,7 @@ Per-package settings can be defined in two places:
 | `registry`            | `string`                   | Custom npm registry URL                                                 |
 | `skipNpmPublish`      | `boolean`                  | Don't publish to npm (still creates git tags)                           |
 | `checkPublished`      | `string`                   | Custom command that outputs the currently published version             |
+| `changedFilePatterns` | `string[]`                 | Glob patterns for changed-file detection (overrides root setting)       |
 | `dependencyBumpRules` | `object`                   | Per-package override for dependency propagation rules                   |
 | `cascadeTo`           | `object`                   | Explicit cascade targets — glob pattern mapped to `{ trigger, bumpAs }` |
 
@@ -155,7 +166,7 @@ Or in the package's `package.json` (requires `allowCustomCommands`):
 
 ## Changelog formatters
 
-Set `changelog` in config to control how changelog entries are generated. Built-in options are `"default"` and `"github"`, or you can provide a path to a custom formatter module.
+Set `changelog` in config to control how changelog entries are generated. Built-in options are `"default"` and `"github"`, or you can provide a path to a custom formatter module. Set to `false` to disable changelog generation entirely.
 
 See the [Changelog Formatters](./changelog-formatters.md) docs for full details and examples.
 

--- a/packages/bumpy/config-schema.json
+++ b/packages/bumpy/config-schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/dmno-dev/bumpy/main/packages/bumpy/config-schema.json",
+  "title": "Bumpy Configuration",
+  "description": "Configuration for @varlock/bumpy — monorepo versioning and changelog tool",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Path or URL to the JSON schema"
+    },
+    "baseBranch": {
+      "type": "string",
+      "description": "Branch used for release comparisons",
+      "default": "main"
+    },
+    "access": {
+      "type": "string",
+      "enum": ["public", "restricted"],
+      "description": "Default npm publish access level",
+      "default": "public"
+    },
+    "commit": {
+      "description": "Auto-commit changes after `bumpy version`. false = don't commit, true = commit with default message, or an object for custom message.",
+      "default": false,
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Static commit message"
+            },
+            "generateFn": {
+              "type": "string",
+              "description": "Path to a module that exports a function to generate the commit message. The function receives the release plan as its argument."
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "changelog": {
+      "description": "Changelog formatter — \"default\", \"github\", or path to a custom formatter. Can also be a tuple of [formatter, options]. Set to false to disable changelog generation.",
+      "default": "default",
+      "oneOf": [
+        { "type": "boolean", "const": false },
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": [{ "type": "string" }, { "type": "object" }],
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    "changedFilePatterns": {
+      "type": "array",
+      "description": "Glob patterns to filter which changed files count toward marking a package as changed. Can be overridden per-package.",
+      "items": { "type": "string" },
+      "default": ["**"]
+    },
+    "fixed": {
+      "type": "array",
+      "description": "Package groups that always bump together to the same version. Each element is an array of package name globs.",
+      "items": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "default": []
+    },
+    "linked": {
+      "type": "array",
+      "description": "Package groups that share the highest bump level. Each element is an array of package name globs.",
+      "items": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "default": []
+    },
+    "ignore": {
+      "type": "array",
+      "description": "Package name globs to exclude from versioning",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "include": {
+      "type": "array",
+      "description": "Package name globs to explicitly include (overrides ignore and privatePackages)",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "updateInternalDependencies": {
+      "type": "string",
+      "enum": ["patch", "minor", "out-of-range"],
+      "description": "When to update internal dependency version ranges",
+      "default": "out-of-range"
+    },
+    "dependencyBumpRules": {
+      "type": "object",
+      "description": "Controls how bumps propagate through dependency types",
+      "properties": {
+        "dependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+        "devDependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+        "peerDependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+        "optionalDependencies": { "$ref": "#/$defs/dependencyBumpRule" }
+      },
+      "additionalProperties": false
+    },
+    "privatePackages": {
+      "type": "object",
+      "description": "Whether to version and/or create git tags for private packages",
+      "properties": {
+        "version": {
+          "type": "boolean",
+          "description": "Whether to version private packages",
+          "default": false
+        },
+        "tag": {
+          "type": "boolean",
+          "description": "Whether to create git tags for private packages",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "allowCustomCommands": {
+      "description": "Allow per-package custom commands (buildCommand, publishCommand, checkPublished) defined in package.json \"bumpy\" fields. true = allow all, string[] = allow matching package name globs, false = only root-config commands allowed.",
+      "default": false,
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "packages": {
+      "type": "object",
+      "description": "Per-package config overrides, keyed by package name or glob pattern",
+      "additionalProperties": { "$ref": "#/$defs/packageConfig" }
+    },
+    "publish": {
+      "type": "object",
+      "description": "Publishing pipeline configuration",
+      "properties": {
+        "packManager": {
+          "type": "string",
+          "enum": ["auto", "npm", "pnpm", "bun", "yarn"],
+          "description": "Package manager to use for packing. \"auto\" detects from lockfile.",
+          "default": "auto"
+        },
+        "publishManager": {
+          "type": "string",
+          "enum": ["npm", "pnpm", "bun", "yarn"],
+          "description": "Command to use for publishing. npm supports OIDC/provenance.",
+          "default": "npm"
+        },
+        "publishArgs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra args appended to the publish command (e.g., \"--provenance\")",
+          "default": []
+        },
+        "protocolResolution": {
+          "type": "string",
+          "enum": ["pack", "in-place", "none"],
+          "description": "How to handle workspace:/catalog: protocol resolution. \"pack\" = use PM's pack to build a clean tarball, \"in-place\" = rewrite package.json before publish, \"none\" = don't resolve.",
+          "default": "pack"
+        }
+      },
+      "additionalProperties": false
+    },
+    "aggregateRelease": {
+      "description": "GitHub release creation (requires gh CLI). false = individual release per package, true = single aggregated release, or an object with enabled and optional title (supports {{date}}).",
+      "default": false,
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to create an aggregated release"
+            },
+            "title": {
+              "type": "string",
+              "description": "Custom title for the aggregated release (supports {{date}})"
+            }
+          },
+          "required": ["enabled"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "gitUser": {
+      "type": "object",
+      "description": "Git identity used for CI commits",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Git user name",
+          "default": "bumpy-bot"
+        },
+        "email": {
+          "type": "string",
+          "description": "Git user email",
+          "default": "276066384+bumpy-bot@users.noreply.github.com"
+        }
+      },
+      "additionalProperties": false
+    },
+    "versionPr": {
+      "type": "object",
+      "description": "Customize the version PR created by bumpy ci release",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "PR title",
+          "default": "🐸 Versioned release"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Branch name for the version PR",
+          "default": "bumpy/version-packages"
+        },
+        "preamble": {
+          "type": "string",
+          "description": "HTML/markdown content prepended to the PR body"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "bumpType": {
+      "type": "string",
+      "enum": ["major", "minor", "patch"]
+    },
+    "dependencyBumpRule": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "trigger": {
+              "$ref": "#/$defs/bumpType",
+              "description": "Minimum bump level that triggers propagation"
+            },
+            "bumpAs": {
+              "description": "What level to bump the dependent (\"match\" mirrors the triggering level)",
+              "oneOf": [{ "$ref": "#/$defs/bumpType" }, { "type": "string", "const": "match" }]
+            }
+          },
+          "required": ["trigger", "bumpAs"],
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "description": "Set to false to disable propagation for this dependency type"
+        }
+      ]
+    },
+    "packageConfig": {
+      "type": "object",
+      "description": "Per-package configuration",
+      "properties": {
+        "managed": {
+          "type": "boolean",
+          "description": "Explicitly opt this package in or out of version management"
+        },
+        "access": {
+          "type": "string",
+          "enum": ["public", "restricted"],
+          "description": "Override the global access level"
+        },
+        "publishCommand": {
+          "description": "Custom command(s) to publish this package (replaces npm publish)",
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        },
+        "buildCommand": {
+          "type": "string",
+          "description": "Command to run before publishing"
+        },
+        "registry": {
+          "type": "string",
+          "description": "Custom npm registry URL"
+        },
+        "skipNpmPublish": {
+          "type": "boolean",
+          "description": "Don't publish to npm (still creates git tags)"
+        },
+        "checkPublished": {
+          "type": "string",
+          "description": "Custom command that outputs the currently published version"
+        },
+        "changedFilePatterns": {
+          "type": "array",
+          "description": "Glob patterns to filter which changed files count toward marking this package as changed (overrides root setting)",
+          "items": { "type": "string" }
+        },
+        "dependencyBumpRules": {
+          "type": "object",
+          "description": "Per-package override for dependency propagation rules",
+          "properties": {
+            "dependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+            "devDependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+            "peerDependencies": { "$ref": "#/$defs/dependencyBumpRule" },
+            "optionalDependencies": { "$ref": "#/$defs/dependencyBumpRule" }
+          },
+          "additionalProperties": false
+        },
+        "cascadeTo": {
+          "type": "object",
+          "description": "Explicit cascade targets — glob pattern mapped to { trigger, bumpAs }",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "trigger": {
+                "$ref": "#/$defs/bumpType",
+                "description": "Minimum bump level that triggers the cascade"
+              },
+              "bumpAs": {
+                "description": "What level to bump the target",
+                "oneOf": [{ "$ref": "#/$defs/bumpType" }, { "type": "string", "const": "match" }]
+              }
+            },
+            "required": ["trigger", "bumpAs"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/bumpy/config-schema.json
+++ b/packages/bumpy/config-schema.json
@@ -20,11 +20,10 @@
       "description": "Default npm publish access level",
       "default": "public"
     },
-    "commit": {
-      "description": "Auto-commit changes after `bumpy version`. false = don't commit, true = commit with default message, or an object for custom message.",
-      "default": false,
+    "versionCommitMessage": {
+      "description": "Customize the commit message used when versioning (by `bumpy version --commit` and CI commands). Omit to use the default message.",
       "oneOf": [
-        { "type": "boolean" },
+        { "type": "string", "description": "Static commit message" },
         {
           "type": "object",
           "properties": {

--- a/packages/bumpy/config-schema.json
+++ b/packages/bumpy/config-schema.json
@@ -21,24 +21,8 @@
       "default": "public"
     },
     "versionCommitMessage": {
-      "description": "Customize the commit message used when versioning (by `bumpy version --commit` and CI commands). Omit to use the default message.",
-      "oneOf": [
-        { "type": "string", "description": "Static commit message" },
-        {
-          "type": "object",
-          "properties": {
-            "message": {
-              "type": "string",
-              "description": "Static commit message"
-            },
-            "generateFn": {
-              "type": "string",
-              "description": "Path to a module that exports a function to generate the commit message. The function receives the release plan as its argument."
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
+      "type": "string",
+      "description": "Customize the commit message used when versioning. A plain string is used as-is. A path starting with \"./\" or \"../\" is loaded as a module that exports a function receiving the release plan and returning a message string."
     },
     "changelog": {
       "description": "Changelog formatter — \"default\", \"github\", or path to a custom formatter. Can also be a tuple of [formatter, options]. Set to false to disable changelog generation.",

--- a/packages/bumpy/package.json
+++ b/packages/bumpy/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "config-schema.json",
     ".claude-plugin",
     "skills"
   ],
@@ -43,9 +44,11 @@
     "@clack/prompts": "^1.2.0",
     "@types/bun": "latest",
     "@types/js-yaml": "^4.0.9",
+    "@types/picomatch": "^4.0.3",
     "@types/semver": "^7.7.0",
     "js-yaml": "^4.1.0",
     "picocolors": "^1.1.1",
+    "picomatch": "^4.0.4",
     "semver": "^7.7.2",
     "tsdown": "catalog:"
   }

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -64,7 +64,9 @@ async function main() {
       case 'version': {
         const rootDir = await findRoot();
         const { versionCommand } = await import('./commands/version.ts');
-        await versionCommand(rootDir);
+        await versionCommand(rootDir, {
+          commit: flags.commit === true,
+        });
         break;
       }
 
@@ -190,7 +192,7 @@ function printHelp() {
     generate                Generate bump file from branch commits
     status                  Show pending releases
     check                   Verify changed packages have bump files (for pre-push hooks)
-    version                 Apply bump files and bump versions
+    version [--commit]      Apply bump files and bump versions
     publish                 Publish versioned packages
     ci check                PR check — report pending releases, comment on PR
     ci release              Release — create version PR or auto-publish

--- a/packages/bumpy/src/commands/add.ts
+++ b/packages/bumpy/src/commands/add.ts
@@ -5,10 +5,10 @@ import { p, unwrap } from '../utils/clack.ts';
 import { ensureDir, exists } from '../utils/fs.ts';
 import { randomName, slugify } from '../utils/names.ts';
 import { writeBumpFile } from '../core/bump-file.ts';
-import { getBumpyDir, loadConfig } from '../core/config.ts';
+import picomatch from 'picomatch';
+import { getBumpyDir, loadConfig, loadPackageConfig, matchGlob } from '../core/config.ts';
 import { discoverPackages } from '../core/workspace.ts';
 import { DependencyGraph } from '../core/dep-graph.ts';
-import { matchGlob } from '../core/config.ts';
 import { getChangedFiles } from '../core/git.ts';
 import { bumpSelectPrompt } from '../prompts/bump-select.ts';
 import type { BumpSelectItem } from '../prompts/bump-select.ts';
@@ -66,12 +66,23 @@ export async function addCommand(rootDir: string, opts: AddOptions): Promise<voi
     // Detect which packages have changed on this branch
     const baseBranch = config.baseBranch;
     const changedFiles = getChangedFiles(rootDir, baseBranch);
+    // Build per-package matchers (per-package patterns override root patterns)
+    const matchers = new Map<string, picomatch.Matcher>();
+    for (const [name, pkg] of pkgs) {
+      const pkgConfig = await loadPackageConfig(pkg.dir, config, name);
+      const patterns = pkgConfig.changedFilePatterns ?? config.changedFilePatterns;
+      matchers.set(name, picomatch(patterns));
+    }
+
     const changedPackageNames = new Set<string>();
     for (const file of changedFiles) {
       for (const [name, pkg] of pkgs) {
         const pkgRelDir = relative(rootDir, pkg.dir);
         if (file.startsWith(pkgRelDir + '/')) {
-          changedPackageNames.add(name);
+          const relToPackage = file.slice(pkgRelDir.length + 1);
+          if (matchers.get(name)!(relToPackage)) {
+            changedPackageNames.add(name);
+          }
         }
       }
     }

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -1,10 +1,11 @@
 import { relative } from 'node:path';
+import picomatch from 'picomatch';
 import { log, colorize } from '../utils/logger.ts';
-import { loadConfig } from '../core/config.ts';
+import { loadConfig, loadPackageConfig } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
 import { getChangedFiles } from '../core/git.ts';
-import type { WorkspacePackage } from '../types.ts';
+import type { BumpyConfig, WorkspacePackage } from '../types.ts';
 
 /**
  * Local check: detect which packages have changed on this branch
@@ -43,7 +44,7 @@ export async function checkCommand(rootDir: string): Promise<void> {
     }
   }
 
-  const changedPackages = findChangedPackages(changedFiles, packages, rootDir);
+  const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
 
   if (changedPackages.length === 0) {
     log.info('No managed packages have changed.');
@@ -69,18 +70,30 @@ export async function checkCommand(rootDir: string): Promise<void> {
 }
 
 /** Map changed files to the packages they belong to */
-function findChangedPackages(
+async function findChangedPackages(
   changedFiles: string[],
   packages: Map<string, WorkspacePackage>,
   rootDir: string,
-): string[] {
+  config: BumpyConfig,
+): Promise<string[]> {
   const changed = new Set<string>();
+
+  // Build per-package matchers (per-package patterns override root patterns)
+  const matchers = new Map<string, picomatch.Matcher>();
+  for (const [name, pkg] of packages) {
+    const pkgConfig = await loadPackageConfig(pkg.dir, config, name);
+    const patterns = pkgConfig.changedFilePatterns ?? config.changedFilePatterns;
+    matchers.set(name, picomatch(patterns));
+  }
 
   for (const file of changedFiles) {
     for (const [name, pkg] of packages) {
       const pkgRelDir = relative(rootDir, pkg.dir);
       if (file.startsWith(pkgRelDir + '/')) {
-        changed.add(name);
+        const relToPackage = file.slice(pkgRelDir.length + 1);
+        if (matchers.get(name)!(relToPackage)) {
+          changed.add(name);
+        }
       }
     }
   }

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -9,6 +9,7 @@ import { runArgs, runArgsAsync, tryRunArgs } from '../utils/shell.ts';
 import { randomName } from '../utils/names.ts';
 import { detectPackageManager } from '../utils/package-manager.ts';
 import { createHash } from 'node:crypto';
+import { resolveCommitMessage } from '../core/commit-message.ts';
 import type { BumpyConfig, BumpFile, PackageManager, ReleasePlan, PlannedRelease } from '../types.ts';
 
 // ---- PAT-scoped gh helpers ----
@@ -197,7 +198,7 @@ export async function ciReleaseCommand(rootDir: string, opts: ReleaseOptions): P
   }
 
   if (opts.mode === 'auto-publish') {
-    await autoPublish(rootDir, config, opts.tag);
+    await autoPublish(rootDir, config, plan, opts.tag);
   } else {
     const packageDirs = new Map([...packages.values()].map((p) => [p.name, p.relativeDir]));
     await createVersionPr(rootDir, plan, config, packageDirs, opts.branch, opts.patPr);
@@ -206,7 +207,7 @@ export async function ciReleaseCommand(rootDir: string, opts: ReleaseOptions): P
 
 // ---- auto-publish mode ----
 
-async function autoPublish(rootDir: string, config: BumpyConfig, tag?: string): Promise<void> {
+async function autoPublish(rootDir: string, config: BumpyConfig, plan: ReleasePlan, tag?: string): Promise<void> {
   log.step('Running bumpy version...');
   const { versionCommand } = await import('./version.ts');
   await versionCommand(rootDir);
@@ -216,7 +217,8 @@ async function autoPublish(rootDir: string, config: BumpyConfig, tag?: string): 
   runArgs(['git', 'add', '-A'], { cwd: rootDir });
   const status = tryRunArgs(['git', 'status', '--porcelain'], { cwd: rootDir });
   if (status) {
-    runArgs(['git', 'commit', '-m', 'Version packages'], { cwd: rootDir });
+    const commitMsg = await resolveCommitMessage(config.versionCommitMessage, plan, rootDir);
+    runArgs(['git', 'commit', '-F', '-'], { cwd: rootDir, input: commitMsg });
     runArgs(['git', 'push', '--no-verify'], { cwd: rootDir });
   }
 
@@ -361,7 +363,7 @@ async function createVersionPr(
     return;
   }
 
-  const commitMsg = ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
+  const commitMsg = await resolveCommitMessage(config.versionCommitMessage, plan, rootDir);
   runArgs(['git', 'commit', '-F', '-'], { cwd: rootDir, input: commitMsg });
 
   pushWithToken(rootDir, branch, config);

--- a/packages/bumpy/src/commands/init.ts
+++ b/packages/bumpy/src/commands/init.ts
@@ -2,7 +2,6 @@ import { resolve } from 'node:path';
 import { ensureDir, writeJson, writeText, exists } from '../utils/fs.ts';
 import { log } from '../utils/logger.ts';
 import { detectPackageManager } from '../utils/package-manager.ts';
-import type { BumpyConfig } from '../types.ts';
 import readmeTemplate from '../../../../.bumpy/README.md';
 
 const PM_RUNNER: Record<string, string> = {
@@ -23,7 +22,8 @@ export async function initCommand(rootDir: string): Promise<void> {
   await ensureDir(bumpyDir);
 
   // Write a minimal config (only non-default values would go here)
-  const config: Partial<BumpyConfig> = {
+  const config: Record<string, unknown> = {
+    $schema: '../node_modules/@varlock/bumpy/config-schema.json',
     baseBranch: 'main',
     changelog: 'default',
   };

--- a/packages/bumpy/src/commands/migrate.ts
+++ b/packages/bumpy/src/commands/migrate.ts
@@ -111,7 +111,6 @@ async function migrateConfig(changesetConfigPath: string, bumpyDir: string): Pro
   const migrateableFields = [
     'baseBranch',
     'access',
-    'commit',
     'fixed',
     'linked',
     'ignore',
@@ -123,6 +122,14 @@ async function migrateConfig(changesetConfigPath: string, bumpyDir: string): Pro
     if (csConfig[field] !== undefined) {
       bumpyConfig[field] = csConfig[field];
     }
+  }
+
+  // Migrate commit (changesets supports boolean | string | [string, options], bumpy only takes boolean for simple migration)
+  if (typeof csConfig.commit === 'boolean') {
+    bumpyConfig.commit = csConfig.commit;
+  } else if (csConfig.commit) {
+    bumpyConfig.commit = true;
+    log.warn('Changesets custom commit message module not migrated — using `commit: true` instead.');
   }
 
   // Note: changesets' changelog, ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH, etc. are not migrated

--- a/packages/bumpy/src/commands/migrate.ts
+++ b/packages/bumpy/src/commands/migrate.ts
@@ -124,15 +124,7 @@ async function migrateConfig(changesetConfigPath: string, bumpyDir: string): Pro
     }
   }
 
-  // Migrate commit (changesets supports boolean | string | [string, options], bumpy only takes boolean for simple migration)
-  if (typeof csConfig.commit === 'boolean') {
-    bumpyConfig.commit = csConfig.commit;
-  } else if (csConfig.commit) {
-    bumpyConfig.commit = true;
-    log.warn('Changesets custom commit message module not migrated — using `commit: true` instead.');
-  }
-
-  // Note: changesets' changelog, ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH, etc. are not migrated
+  // Note: changesets' commit, changelog, ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH, etc. are not migrated
   // The user should configure these manually
 
   const { writeJson } = await import('../utils/fs.ts');

--- a/packages/bumpy/src/commands/version.ts
+++ b/packages/bumpy/src/commands/version.ts
@@ -5,7 +5,6 @@ import { DependencyGraph } from '../core/dep-graph.ts';
 import { readBumpFiles } from '../core/bump-file.ts';
 import { assembleReleasePlan } from '../core/release-plan.ts';
 import { applyReleasePlan } from '../core/apply-release-plan.ts';
-import { resolve } from 'node:path';
 import { runArgs, tryRunArgs } from '../utils/shell.ts';
 import { detectWorkspaces } from '../utils/package-manager.ts';
 import { resolveCommitMessage } from '../core/commit-message.ts';

--- a/packages/bumpy/src/commands/version.ts
+++ b/packages/bumpy/src/commands/version.ts
@@ -5,8 +5,10 @@ import { DependencyGraph } from '../core/dep-graph.ts';
 import { readBumpFiles } from '../core/bump-file.ts';
 import { assembleReleasePlan } from '../core/release-plan.ts';
 import { applyReleasePlan } from '../core/apply-release-plan.ts';
+import { resolve } from 'node:path';
 import { runArgs, tryRunArgs } from '../utils/shell.ts';
 import { detectWorkspaces } from '../utils/package-manager.ts';
+import type { ReleasePlan, CommitConfig } from '../types.ts';
 
 export async function versionCommand(rootDir: string): Promise<void> {
   const config = await loadConfig(rootDir);
@@ -64,7 +66,7 @@ export async function versionCommand(rootDir: string): Promise<void> {
       for (const lockfile of ['bun.lock', 'bun.lockb', 'pnpm-lock.yaml', 'yarn.lock', 'package-lock.json']) {
         tryRunArgs(['git', 'add', '--', lockfile], { cwd: rootDir });
       }
-      const msg = ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
+      const msg = await resolveCommitMessage(config.commit, plan, rootDir);
       runArgs(['git', 'commit', '-F', '-'], { cwd: rootDir, input: msg });
       log.success('Created git commit');
     } catch (e) {
@@ -85,6 +87,26 @@ async function updateLockfile(rootDir: string): Promise<void> {
   } catch (err) {
     log.warn(`  Lockfile update failed: ${err instanceof Error ? err.message : err}`);
   }
+}
+
+async function resolveCommitMessage(commit: true | CommitConfig, plan: ReleasePlan, rootDir: string): Promise<string> {
+  const defaultMsg = ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
+
+  if (commit === true) return defaultMsg;
+
+  if (commit.message) return commit.message;
+
+  if (commit.generateFn) {
+    const fnPath = resolve(rootDir, commit.generateFn);
+    const mod = await import(fnPath);
+    const fn = mod.default ?? mod;
+    if (typeof fn !== 'function') {
+      throw new Error(`commit.generateFn module "${commit.generateFn}" must export a function`);
+    }
+    return fn(plan);
+  }
+
+  return defaultMsg;
 }
 
 function getInstallArgs(pm: string): string[] {

--- a/packages/bumpy/src/commands/version.ts
+++ b/packages/bumpy/src/commands/version.ts
@@ -8,9 +8,13 @@ import { applyReleasePlan } from '../core/apply-release-plan.ts';
 import { resolve } from 'node:path';
 import { runArgs, tryRunArgs } from '../utils/shell.ts';
 import { detectWorkspaces } from '../utils/package-manager.ts';
-import type { ReleasePlan, CommitConfig } from '../types.ts';
+import { resolveCommitMessage } from '../core/commit-message.ts';
 
-export async function versionCommand(rootDir: string): Promise<void> {
+interface VersionOptions {
+  commit?: boolean;
+}
+
+export async function versionCommand(rootDir: string, opts: VersionOptions = {}): Promise<void> {
   const config = await loadConfig(rootDir);
   const packages = await discoverPackages(rootDir, config);
   const depGraph = new DependencyGraph(packages);
@@ -53,7 +57,7 @@ export async function versionCommand(rootDir: string): Promise<void> {
   await updateLockfile(rootDir);
 
   // Optionally commit
-  if (config.commit) {
+  if (opts.commit) {
     try {
       // Stage version changes, changelogs, deleted bump files, and lockfile
       runArgs(['git', 'add', '-A', '.bumpy/'], { cwd: rootDir });
@@ -66,7 +70,7 @@ export async function versionCommand(rootDir: string): Promise<void> {
       for (const lockfile of ['bun.lock', 'bun.lockb', 'pnpm-lock.yaml', 'yarn.lock', 'package-lock.json']) {
         tryRunArgs(['git', 'add', '--', lockfile], { cwd: rootDir });
       }
-      const msg = await resolveCommitMessage(config.commit, plan, rootDir);
+      const msg = await resolveCommitMessage(config.versionCommitMessage, plan, rootDir);
       runArgs(['git', 'commit', '-F', '-'], { cwd: rootDir, input: msg });
       log.success('Created git commit');
     } catch (e) {
@@ -87,26 +91,6 @@ async function updateLockfile(rootDir: string): Promise<void> {
   } catch (err) {
     log.warn(`  Lockfile update failed: ${err instanceof Error ? err.message : err}`);
   }
-}
-
-async function resolveCommitMessage(commit: true | CommitConfig, plan: ReleasePlan, rootDir: string): Promise<string> {
-  const defaultMsg = ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
-
-  if (commit === true) return defaultMsg;
-
-  if (commit.message) return commit.message;
-
-  if (commit.generateFn) {
-    const fnPath = resolve(rootDir, commit.generateFn);
-    const mod = await import(fnPath);
-    const fn = mod.default ?? mod;
-    if (typeof fn !== 'function') {
-      throw new Error(`commit.generateFn module "${commit.generateFn}" must export a function`);
-    }
-    return fn(plan);
-  }
-
-  return defaultMsg;
 }
 
 function getInstallArgs(pm: string): string[] {

--- a/packages/bumpy/src/core/apply-release-plan.ts
+++ b/packages/bumpy/src/core/apply-release-plan.ts
@@ -21,7 +21,7 @@ export async function applyReleasePlan(
   config: BumpyConfig,
 ): Promise<void> {
   const releaseMap = new Map(releasePlan.releases.map((r) => [r.name, r]));
-  const formatter = await loadFormatter(config.changelog, rootDir);
+  const formatter = config.changelog !== false ? await loadFormatter(config.changelog, rootDir) : null;
 
   // 1. Update package.json versions and internal dependency ranges (preserving formatting)
   for (const release of releasePlan.releases) {
@@ -46,17 +46,19 @@ export async function applyReleasePlan(
   }
 
   // 2. Update changelogs
-  for (const release of releasePlan.releases) {
-    const pkg = packages.get(release.name)!;
-    const changelogPath = resolve(pkg.dir, 'CHANGELOG.md');
+  if (formatter) {
+    for (const release of releasePlan.releases) {
+      const pkg = packages.get(release.name)!;
+      const changelogPath = resolve(pkg.dir, 'CHANGELOG.md');
 
-    const entry = await generateChangelogEntry(release, releasePlan.bumpFiles, formatter);
-    let existingContent = '';
-    if (await exists(changelogPath)) {
-      existingContent = await readText(changelogPath);
+      const entry = await generateChangelogEntry(release, releasePlan.bumpFiles, formatter);
+      let existingContent = '';
+      if (await exists(changelogPath)) {
+        existingContent = await readText(changelogPath);
+      }
+      const newContent = prependToChangelog(existingContent, entry);
+      await writeText(changelogPath, newContent);
     }
-    const newContent = prependToChangelog(existingContent, entry);
-    await writeText(changelogPath, newContent);
   }
 
   // 3. Delete all bump files (including empty ones that aren't in the release plan)

--- a/packages/bumpy/src/core/commit-message.ts
+++ b/packages/bumpy/src/core/commit-message.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import type { ReleasePlan, VersionCommitMessageConfig } from '../types.ts';
+import type { ReleasePlan } from '../types.ts';
 
 /** Build the default version commit message */
 function defaultCommitMessage(plan: ReleasePlan): string {
@@ -8,25 +8,23 @@ function defaultCommitMessage(plan: ReleasePlan): string {
 
 /** Resolve the commit message from config, falling back to the default */
 export async function resolveCommitMessage(
-  config: string | VersionCommitMessageConfig | undefined,
+  config: string | undefined,
   plan: ReleasePlan,
   rootDir: string,
 ): Promise<string> {
   if (!config) return defaultCommitMessage(plan);
 
-  if (typeof config === 'string') return config;
-
-  if (config.message) return config.message;
-
-  if (config.generateFn) {
-    const fnPath = resolve(rootDir, config.generateFn);
+  // Paths starting with "./" or "../" are treated as module paths
+  if (config.startsWith('./') || config.startsWith('../')) {
+    const fnPath = resolve(rootDir, config);
     const mod = await import(fnPath);
     const fn = mod.default ?? mod;
     if (typeof fn !== 'function') {
-      throw new Error(`versionCommitMessage.generateFn module "${config.generateFn}" must export a function`);
+      throw new Error(`versionCommitMessage module "${config}" must export a function`);
     }
     return fn(plan);
   }
 
-  return defaultCommitMessage(plan);
+  // Otherwise it's a static message
+  return config;
 }

--- a/packages/bumpy/src/core/commit-message.ts
+++ b/packages/bumpy/src/core/commit-message.ts
@@ -1,0 +1,32 @@
+import { resolve } from 'node:path';
+import type { ReleasePlan, VersionCommitMessageConfig } from '../types.ts';
+
+/** Build the default version commit message */
+function defaultCommitMessage(plan: ReleasePlan): string {
+  return ['Version packages', '', ...plan.releases.map((r) => `${r.name}@${r.newVersion}`)].join('\n');
+}
+
+/** Resolve the commit message from config, falling back to the default */
+export async function resolveCommitMessage(
+  config: string | VersionCommitMessageConfig | undefined,
+  plan: ReleasePlan,
+  rootDir: string,
+): Promise<string> {
+  if (!config) return defaultCommitMessage(plan);
+
+  if (typeof config === 'string') return config;
+
+  if (config.message) return config.message;
+
+  if (config.generateFn) {
+    const fnPath = resolve(rootDir, config.generateFn);
+    const mod = await import(fnPath);
+    const fn = mod.default ?? mod;
+    if (typeof fn !== 'function') {
+      throw new Error(`versionCommitMessage.generateFn module "${config.generateFn}" must export a function`);
+    }
+    return fn(plan);
+  }
+
+  return defaultCommitMessage(plan);
+}

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -39,6 +39,13 @@ export const DEP_TYPES: DepType[] = ['dependencies', 'devDependencies', 'peerDep
 
 // ---- Config ----
 
+export interface CommitConfig {
+  /** Static commit message */
+  message?: string;
+  /** Path to a module that exports a function to generate the commit message */
+  generateFn?: string;
+}
+
 export interface PublishConfig {
   /** Package manager to use for packing. "auto" detects from lockfile. Default: "auto" */
   packManager: 'auto' | 'npm' | 'pnpm' | 'bun' | 'yarn';
@@ -59,10 +66,19 @@ export interface PublishConfig {
 export interface BumpyConfig {
   baseBranch: string;
   access: 'public' | 'restricted';
-  commit: boolean;
-  changelog: string | [string, Record<string, unknown>];
+  /**
+   * Auto-commit changes after `bumpy version`.
+   * false = don't commit (default)
+   * true = commit with default message
+   * { message: "..." } = commit with a static custom message
+   * { generateFn: "./path.ts" } = commit with a dynamically generated message
+   */
+  commit: boolean | CommitConfig;
+  changelog: false | string | [string, Record<string, unknown>];
   fixed: string[][];
   linked: string[][];
+  /** Glob patterns to filter which changed files count toward marking a package as changed */
+  changedFilePatterns: string[];
   /** Package names/globs to exclude from version management */
   ignore: string[];
   /** Package names/globs to explicitly include (overrides private + ignore) */
@@ -112,6 +128,8 @@ export interface PackageConfig {
   skipNpmPublish?: boolean;
   /** Command to check if a version is already published. Should output the published version string. */
   checkPublished?: string;
+  /** Glob patterns to filter which changed files count toward marking this package as changed */
+  changedFilePatterns?: string[];
   dependencyBumpRules?: Partial<Record<DepType, DependencyBumpRule | false>>;
   cascadeTo?: Record<string, DependencyBumpRule>;
 }
@@ -127,6 +145,7 @@ export const DEFAULT_CONFIG: BumpyConfig = {
   baseBranch: 'main',
   access: 'public',
   commit: false,
+  changedFilePatterns: ['**'],
   changelog: 'default',
   fixed: [],
   linked: [],

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -39,7 +39,7 @@ export const DEP_TYPES: DepType[] = ['dependencies', 'devDependencies', 'peerDep
 
 // ---- Config ----
 
-export interface CommitConfig {
+export interface VersionCommitMessageConfig {
   /** Static commit message */
   message?: string;
   /** Path to a module that exports a function to generate the commit message */
@@ -67,13 +67,13 @@ export interface BumpyConfig {
   baseBranch: string;
   access: 'public' | 'restricted';
   /**
-   * Auto-commit changes after `bumpy version`.
-   * false = don't commit (default)
-   * true = commit with default message
-   * { message: "..." } = commit with a static custom message
-   * { generateFn: "./path.ts" } = commit with a dynamically generated message
+   * Customize the commit message used when versioning.
+   * string = static commit message
+   * { message: "..." } = static commit message
+   * { generateFn: "./path.ts" } = dynamically generated message (module receives the release plan)
+   * Omit to use the default: "Version packages\n\npkg@version..."
    */
-  commit: boolean | CommitConfig;
+  versionCommitMessage?: string | VersionCommitMessageConfig;
   changelog: false | string | [string, Record<string, unknown>];
   fixed: string[][];
   linked: string[][];
@@ -144,7 +144,7 @@ export const DEFAULT_PUBLISH_CONFIG: PublishConfig = {
 export const DEFAULT_CONFIG: BumpyConfig = {
   baseBranch: 'main',
   access: 'public',
-  commit: false,
+  versionCommitMessage: undefined,
   changedFilePatterns: ['**'],
   changelog: 'default',
   fixed: [],

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -39,13 +39,6 @@ export const DEP_TYPES: DepType[] = ['dependencies', 'devDependencies', 'peerDep
 
 // ---- Config ----
 
-export interface VersionCommitMessageConfig {
-  /** Static commit message */
-  message?: string;
-  /** Path to a module that exports a function to generate the commit message */
-  generateFn?: string;
-}
-
 export interface PublishConfig {
   /** Package manager to use for packing. "auto" detects from lockfile. Default: "auto" */
   packManager: 'auto' | 'npm' | 'pnpm' | 'bun' | 'yarn';
@@ -68,12 +61,12 @@ export interface BumpyConfig {
   access: 'public' | 'restricted';
   /**
    * Customize the commit message used when versioning.
-   * string = static commit message
-   * { message: "..." } = static commit message
-   * { generateFn: "./path.ts" } = dynamically generated message (module receives the release plan)
+   * A string starting with "./" is treated as a path to a module that exports
+   * a function receiving the release plan and returning a message string.
+   * Any other string is used as a static commit message.
    * Omit to use the default: "Version packages\n\npkg@version..."
    */
-  versionCommitMessage?: string | VersionCommitMessageConfig;
+  versionCommitMessage?: string;
   changelog: false | string | [string, Record<string, unknown>];
   fixed: string[][];
   linked: string[][];

--- a/packages/bumpy/test/core/migrate.test.ts
+++ b/packages/bumpy/test/core/migrate.test.ts
@@ -46,7 +46,6 @@ describe('migrate command', () => {
     const config = await readJson<Record<string, unknown>>(resolve(tmpDir, '.bumpy/_config.json'));
     expect(config.baseBranch).toBe('develop');
     expect(config.access).toBe('restricted');
-    expect(config.commit).toBe(true);
     expect(config.ignore).toEqual(['@test/internal']);
     expect(config.fixed).toEqual([['@test/core', '@test/types']]);
 


### PR DESCRIPTION
## Summary
- Add published JSON schema (`config-schema.json`) for `.bumpy/_config.json` — provides editor autocomplete, validation, and inline descriptions for all options
- `bumpy init` now includes `$schema` pointing to the local `node_modules` copy so the schema stays in sync with the installed version
- Add `changedFilePatterns` option (root + per-package, powered by picomatch) to control which file changes count toward marking a package as changed
- Add `versionCommitMessage` config option for customizing the version commit message — a plain string is used as-is, a path starting with `./` or `../` is loaded as a module. Used by both `bumpy version --commit` and CI commands
- Add `--commit` flag to `bumpy version` for local auto-commit (replaces old `commit` boolean config)
- Allow `changelog: false` to disable changelog generation entirely
- CI commands (`autoPublish`, `createVersionPr`) now respect `versionCommitMessage`

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 177 existing tests pass
- [ ] Verify JSON schema provides autocomplete in VS Code
- [ ] Test `changedFilePatterns` filtering with per-package overrides
- [ ] Test `bumpy version --commit` with default and custom `versionCommitMessage`
- [ ] Test `changelog: false` skips changelog generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)