### PR TITLE
Rework check commands: --strict and --no-fail flags

### DIFF
--- a/.bumpy/README.md
+++ b/.bumpy/README.md
@@ -26,7 +26,7 @@ bunx bumpy add --packages "package-name:minor,other-package:patch" --message "De
 
 ### By hand
 
-Create a `.md` file in this directory with YAML frontmatter mapping package names to bump levels (`major`, `minor`, or `patch`), and a markdown body for the changelog entry:
+Create a `.md` file in this directory with YAML frontmatter mapping package names to bump levels (`major`, `minor`, `patch`, or `none`), and a markdown body for the changelog entry:
 
 ```markdown
 ---

--- a/.bumpy/fix-empty-bump-detection.md
+++ b/.bumpy/fix-empty-bump-detection.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Rework `bumpy check` and `bumpy ci check` behavior: default mode now only fails when no bump files exist at all (matching changesets), new `--strict` flag requires every changed package to be covered, and `--no-fail` makes checks advisory-only. Also fix false positive "empty bump file found" when deleted bump files appear in git diff.

--- a/docs/bump-files.md
+++ b/docs/bump-files.md
@@ -22,12 +22,12 @@ Fixed locale fallback logic in utils.
 
 ### Bump levels
 
-| Level   | When to use                                                                                   |
-| ------- | --------------------------------------------------------------------------------------------- |
-| `major` | Breaking changes                                                                              |
-| `minor` | New features (backwards-compatible)                                                           |
-| `patch` | Bug fixes, minor improvements                                                                 |
-| `none`  | Suppresses a bump — used in cascades to exclude specific packages from propagation (advanced) |
+| Level   | When to use                                                                                                                                                        |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `major` | Breaking changes                                                                                                                                                   |
+| `minor` | New features (backwards-compatible)                                                                                                                                |
+| `patch` | Bug fixes, minor improvements                                                                                                                                      |
+| `none`  | Acknowledges a change without triggering a release — useful for covering packages in `--strict` mode, or in cascades to exclude specific packages from propagation |
 
 ## File naming
 
@@ -86,7 +86,19 @@ For PRs that intentionally don't need a release (docs, CI changes, etc.), create
 bumpy add --empty --name "docs-update"
 ```
 
-This prevents `bumpy ci check` from warning about missing bump files.
+This prevents `bumpy check` and `bumpy ci check` from failing due to missing bump files.
+
+### `none` bump type
+
+If you're using `--strict` mode (which requires every changed package to be covered), use bump type `none` to acknowledge a package changed without triggering a release:
+
+```markdown
+---
+'@myorg/docs-site': none
+---
+```
+
+This covers the package in strict checks without producing a version bump or changelog entry.
 
 ## Cascade control (advanced)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,13 +90,22 @@ bumpy publish --filter "@myorg/*"
 
 ## `bumpy check`
 
-Verify that all changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages, and exits non-zero if any are missing.
+Verify that changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages.
+
+By default, exits non-zero only if **no** bump files exist at all (matching changesets behavior). Use `--strict` to require every changed package to be covered.
 
 ```bash
 bumpy check
+bumpy check --strict
+bumpy check --no-fail
 ```
 
-No flags. No GitHub API needed.
+| Flag        | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| `--strict`  | Fail if any changed package is not covered by a bump file  |
+| `--no-fail` | Warn only, never exit non-zero (useful for advisory hooks) |
+
+No GitHub API needed.
 
 ## `bumpy generate`
 
@@ -130,14 +139,16 @@ CI command for PR checks. Computes the release plan from bump files changed in t
 
 ```bash
 bumpy ci check
-bumpy ci check --fail-on-missing
+bumpy ci check --strict
+bumpy ci check --no-fail
 ```
 
-| Flag                | Description                                                      |
-| ------------------- | ---------------------------------------------------------------- |
-| `--comment`         | Force PR comment on or off (default: auto-detect CI environment) |
-| `--fail-on-missing` | Exit 1 if changed packages have no bump files                    |
-| `--pat-comments`    | Post PR comments using `BUMPY_GH_TOKEN` instead of `GH_TOKEN`    |
+| Flag             | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `--comment`      | Force PR comment on or off (default: auto-detect CI environment) |
+| `--strict`       | Fail if any changed package is not covered by a bump file        |
+| `--no-fail`      | Warn only, never exit non-zero                                   |
+| `--pat-comments` | Post PR comments using `BUMPY_GH_TOKEN` instead of `GH_TOKEN`    |
 
 Requires `GH_TOKEN` environment variable. The `--pat-comments` flag requires `BUMPY_GH_TOKEN` — use it when the token belongs to a dedicated automation account (bot user). If you're using a developer's personal PAT, leave this off so comments appear from `github-actions[bot]`.
 

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -145,7 +145,7 @@ Custom changelog formatters with full context (release info, bump files, dates).
 
 ### Local bump file verification
 
-`bumpy check` verifies that all changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages, and exits non-zero if any are missing. No GitHub API needed.
+`bumpy check` verifies that changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages. By default it only fails if no bump files exist at all (matching changesets behavior). Use `--strict` to require every changed package to be covered, or `--no-fail` for advisory-only mode. No GitHub API needed.
 
 Changesets has no built-in equivalent — users rely on the CI bot comment to catch missing bump files after pushing.
 

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -93,7 +93,10 @@ async function main() {
       case 'check': {
         const rootDir = await findRoot();
         const { checkCommand } = await import('./commands/check.ts');
-        await checkCommand(rootDir);
+        await checkCommand(rootDir, {
+          strict: flags.strict === true,
+          noFail: flags['no-fail'] === true,
+        });
         break;
       }
 
@@ -106,7 +109,8 @@ async function main() {
           const { ciCheckCommand } = await import('./commands/ci.ts');
           await ciCheckCommand(rootDir, {
             comment: ciFlags.comment !== undefined ? ciFlags.comment === true : undefined,
-            failOnMissing: ciFlags['fail-on-missing'] === true,
+            strict: ciFlags.strict === true,
+            noFail: ciFlags['no-fail'] === true,
             patComments: ciFlags['pat-comments'] === true,
           });
         } else if (subcommand === 'release') {
@@ -192,6 +196,8 @@ function printHelp() {
     generate                Generate bump file from branch commits
     status                  Show pending releases
     check                   Verify changed packages have bump files (for pre-push hooks)
+      --strict                Fail if any changed package is uncovered (default: only fail if no bump files at all)
+      --no-fail               Warn only, never exit 1
     version [--commit]      Apply bump files and bump versions
     publish                 Publish versioned packages
     ci check                PR check — report pending releases, comment on PR
@@ -226,7 +232,8 @@ function printHelp() {
 
   CI check options:
     --comment               Force PR comment on/off (auto-detected in CI)
-    --fail-on-missing       Exit 1 if no bump files found
+    --strict                Fail if any changed package is uncovered (default: only fail if no bump files at all)
+    --no-fail               Warn only, never exit 1
 
   CI release options:
     --auto-publish          Version + publish directly (default: create version PR)

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -1,18 +1,27 @@
 import { relative } from 'node:path';
 import picomatch from 'picomatch';
 import { log, colorize } from '../utils/logger.ts';
-import { loadConfig, loadPackageConfig } from '../core/config.ts';
+import { loadConfig, loadPackageConfig, getBumpyDir } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
 import { getChangedFiles } from '../core/git.ts';
 import type { BumpyConfig, WorkspacePackage } from '../types.ts';
 
+interface CheckOptions {
+  strict?: boolean;
+  noFail?: boolean;
+}
+
 /**
  * Local check: detect which packages have changed on this branch
  * and verify they have corresponding bump files.
  * Designed for pre-push hooks — no GitHub API needed.
+ *
+ * Default: at least one bump file must exist, uncovered packages are warned.
+ * --strict: every changed package must be covered.
+ * --no-fail: warn only, never exit 1.
  */
-export async function checkCommand(rootDir: string): Promise<void> {
+export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Promise<void> {
   const config = await loadConfig(rootDir);
   const { packages } = await discoverWorkspace(rootDir, config);
 
@@ -27,10 +36,9 @@ export async function checkCommand(rootDir: string): Promise<void> {
 
   // Filter to only bump files added/modified on this branch
   const allBumpFiles = await readBumpFiles(rootDir);
-  const { branchBumpFiles, branchBumpFileIds } = filterBranchBumpFiles(allBumpFiles, changedFiles);
+  const { branchBumpFiles, hasEmptyBumpFile } = filterBranchBumpFiles(allBumpFiles, changedFiles, rootDir);
 
-  // If a bump file was changed but didn't parse (empty bump file), the check passes
-  const hasEmptyBumpFile = branchBumpFileIds.size > branchBumpFiles.length;
+  // If an empty bump file exists on this branch, the check passes
   if (hasEmptyBumpFile) {
     log.success('Empty bump file found — no releases needed.');
     return;
@@ -51,6 +59,20 @@ export async function checkCommand(rootDir: string): Promise<void> {
     return;
   }
 
+  // No bump files at all — fail by default
+  const willFailNoBump = !opts.noFail;
+  if (branchBumpFiles.length === 0) {
+    (willFailNoBump ? log.error : log.warn)(`${changedPackages.length} changed package(s) missing bump files:\n`);
+    for (const name of changedPackages) {
+      console.log(`  ${colorize(name, 'yellow')}`);
+    }
+    console.log();
+    log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
+    log.dim('To adjust which files trigger change detection, set `changedFilePatterns` in .bumpy/_config.json.');
+    if (willFailNoBump) process.exit(1);
+    return;
+  }
+
   // Check which changed packages are missing bump files
   const missing = changedPackages.filter((name) => !coveredPackages.has(name));
 
@@ -59,18 +81,35 @@ export async function checkCommand(rootDir: string): Promise<void> {
     return;
   }
 
-  // Report missing
-  log.warn(`${missing.length} changed package(s) missing bump files:\n`);
+  // Some packages uncovered — warn by default, fail with --strict
+  const willFailUncovered = opts.strict && !opts.noFail;
+  (willFailUncovered ? log.error : log.warn)(`${missing.length} changed package(s) missing bump files:\n`);
   for (const name of missing) {
     console.log(`  ${colorize(name, 'yellow')}`);
   }
+
+  if (branchBumpFiles.length > 0) {
+    console.log();
+    log.dim(`Existing bump files on this branch:`);
+    for (const bf of branchBumpFiles) {
+      log.dim(`  ${getBumpyDir(rootDir)}/${bf.id}.md`);
+    }
+  }
+
   console.log();
-  log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
-  process.exit(1);
+  if (opts.strict) {
+    log.dim(
+      "Run `bumpy add` to create a bump file. Use bump type `none` for packages that changed but don't need a release.",
+    );
+  } else {
+    log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
+  }
+  log.dim('To adjust which files trigger change detection, set `changedFilePatterns` in .bumpy/_config.json.');
+  if (willFailUncovered) process.exit(1);
 }
 
 /** Map changed files to the packages they belong to */
-async function findChangedPackages(
+export async function findChangedPackages(
   changedFiles: string[],
   packages: Map<string, WorkspacePackage>,
   rootDir: string,

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -1,5 +1,6 @@
 import { log, colorize } from '../utils/logger.ts';
 import { loadConfig } from '../core/config.ts';
+import { findChangedPackages } from './check.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { DependencyGraph } from '../core/dep-graph.ts';
 import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
@@ -80,7 +81,8 @@ function ensureGitIdentity(rootDir: string, config: BumpyConfig): void {
 
 interface CheckOptions {
   comment?: boolean; // post a PR comment via gh (default: true in CI)
-  failOnMissing?: boolean; // exit 1 if no bump files (default: false)
+  strict?: boolean; // exit 1 if any changed packages are uncovered
+  noFail?: boolean; // never exit 1, warn only
   patComments?: boolean; // post PR comments using BUMPY_GH_TOKEN
 }
 
@@ -108,14 +110,9 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
 
   // Filter to only bump files added/modified in this PR
   const changedFiles = getChangedFiles(rootDir, config.baseBranch);
-  const { branchBumpFiles: prBumpFiles, branchBumpFileIds: prBumpFileIds } = filterBranchBumpFiles(
-    allBumpFiles,
-    changedFiles,
-  );
+  const { branchBumpFiles: prBumpFiles, hasEmptyBumpFile } = filterBranchBumpFiles(allBumpFiles, changedFiles, rootDir);
 
   // An empty bump file signals intentionally no releases needed
-  const hasEmptyBumpFile = prBumpFileIds.size > prBumpFiles.length;
-
   if (hasEmptyBumpFile) {
     log.success('Empty bump file found — no releases needed.');
     if (shouldComment && prNumber) {
@@ -126,17 +123,17 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
   }
 
   if (prBumpFiles.length === 0) {
+    const willFail = !opts.noFail;
     const msg = 'No bump files found in this PR.';
-    log.info(msg);
+    if (willFail) log.error(msg);
+    else log.warn(msg);
 
     if (shouldComment && prNumber) {
       const prBranch = detectPrBranch(rootDir);
       await postOrUpdatePrComment(prNumber, formatNoBumpFilesComment(prBranch, pm), rootDir, opts.patComments);
     }
 
-    if (opts.failOnMissing) {
-      process.exit(1);
-    }
+    if (willFail) process.exit(1);
     return;
   }
 
@@ -159,6 +156,17 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
     const prBranch = detectPrBranch(rootDir);
     const comment = formatReleasePlanComment(plan, prBumpFiles, prNumber, prBranch, pm, plan.warnings);
     await postOrUpdatePrComment(prNumber, comment, rootDir, opts.patComments);
+  }
+
+  // Check for uncovered packages
+  const coveredPackages = new Set(plan.releases.map((r) => r.name));
+  const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
+  const missing = changedPackages.filter((name) => !coveredPackages.has(name));
+  if (missing.length > 0) {
+    const willFail = opts.strict && !opts.noFail;
+    const logFn = willFail ? log.error : log.warn;
+    logFn(`${missing.length} changed package(s) not covered by bump files: ${missing.join(', ')}`);
+    if (willFail) process.exit(1);
   }
 }
 

--- a/packages/bumpy/src/core/bump-file.ts
+++ b/packages/bumpy/src/core/bump-file.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 import yaml from 'js-yaml';
 import { readText, writeText, listFiles, removeFile } from '../utils/fs.ts';
 import { getBumpyDir } from './config.ts';
@@ -187,14 +188,30 @@ export function extractBumpFileIdsFromChangedFiles(changedFiles: string[]): Set<
 
 /**
  * Filter bump files to only those added/modified on the current branch.
- * Returns the filtered bump files and whether any changed bump file was
- * empty (has no releases — signals intentionally no releases needed).
+ * Also detects empty bump files (no releases) that still exist on disk,
+ * which signal intentionally no releases needed.
  */
 export function filterBranchBumpFiles(
   allBumpFiles: BumpFile[],
   changedFiles: string[],
-): { branchBumpFiles: BumpFile[]; branchBumpFileIds: Set<string> } {
+  rootDir?: string,
+): { branchBumpFiles: BumpFile[]; branchBumpFileIds: Set<string>; hasEmptyBumpFile: boolean } {
   const branchBumpFileIds = extractBumpFileIdsFromChangedFiles(changedFiles);
   const branchBumpFiles = allBumpFiles.filter((bf) => branchBumpFileIds.has(bf.id));
-  return { branchBumpFiles, branchBumpFileIds };
+
+  // Check if any changed bump file IDs that didn't parse still exist on disk (= empty bump file).
+  // Deleted bump files (from other branches) should not count.
+  let hasEmptyBumpFile = false;
+  if (rootDir) {
+    const parsedIds = new Set(branchBumpFiles.map((bf) => bf.id));
+    const bumpyDir = getBumpyDir(rootDir);
+    for (const id of branchBumpFileIds) {
+      if (!parsedIds.has(id) && existsSync(resolve(bumpyDir, `${id}.md`))) {
+        hasEmptyBumpFile = true;
+        break;
+      }
+    }
+  }
+
+  return { branchBumpFiles, branchBumpFileIds, hasEmptyBumpFile };
 }

--- a/packages/bumpy/test/core/check.test.ts
+++ b/packages/bumpy/test/core/check.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { resolve } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { extractBumpFileIdsFromChangedFiles, filterBranchBumpFiles } from '../../src/core/bump-file.ts';
+import { makeBumpFile } from '../helpers.ts';
+
+describe('extractBumpFileIdsFromChangedFiles', () => {
+  test('extracts bump file IDs from changed files', () => {
+    const ids = extractBumpFileIdsFromChangedFiles([
+      '.bumpy/my-change.md',
+      '.bumpy/other-fix.md',
+      'packages/core/src/index.ts',
+    ]);
+    expect(ids).toEqual(new Set(['my-change', 'other-fix']));
+  });
+
+  test('ignores README.md', () => {
+    const ids = extractBumpFileIdsFromChangedFiles(['.bumpy/README.md', '.bumpy/real-change.md']);
+    expect(ids).toEqual(new Set(['real-change']));
+  });
+
+  test('ignores non-bumpy files', () => {
+    const ids = extractBumpFileIdsFromChangedFiles(['src/index.ts', 'package.json']);
+    expect(ids).toEqual(new Set());
+  });
+});
+
+describe('filterBranchBumpFiles', () => {
+  test('filters to only bump files in changed list', () => {
+    const all = [
+      makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }]),
+      makeBumpFile('change-b', [{ name: 'pkg-b', type: 'patch' }]),
+    ];
+    const changed = ['.bumpy/change-a.md', 'packages/core/src/index.ts'];
+
+    const { branchBumpFiles } = filterBranchBumpFiles(all, changed);
+    expect(branchBumpFiles).toHaveLength(1);
+    expect(branchBumpFiles[0]!.id).toBe('change-a');
+  });
+
+  test('returns all bump files when all are changed', () => {
+    const all = [
+      makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }]),
+      makeBumpFile('change-b', [{ name: 'pkg-b', type: 'patch' }]),
+    ];
+    const changed = ['.bumpy/change-a.md', '.bumpy/change-b.md'];
+
+    const { branchBumpFiles } = filterBranchBumpFiles(all, changed);
+    expect(branchBumpFiles).toHaveLength(2);
+  });
+
+  test('hasEmptyBumpFile is false when no rootDir provided', () => {
+    const all = [makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }])];
+    const changed = ['.bumpy/change-a.md', '.bumpy/empty-one.md'];
+
+    const { hasEmptyBumpFile } = filterBranchBumpFiles(all, changed);
+    expect(hasEmptyBumpFile).toBe(false);
+  });
+
+  describe('with rootDir (empty bump file detection)', () => {
+    const tmpDir = resolve(import.meta.dir, '../../.test-tmp-check');
+    const bumpyDir = resolve(tmpDir, '.bumpy');
+
+    beforeEach(async () => {
+      await mkdir(bumpyDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    test('detects empty bump file that exists on disk', async () => {
+      // Write an empty bump file to disk
+      await writeFile(resolve(bumpyDir, 'empty-one.md'), '---\n---\n');
+
+      const all = [makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }])];
+      const changed = ['.bumpy/change-a.md', '.bumpy/empty-one.md'];
+
+      const { hasEmptyBumpFile } = filterBranchBumpFiles(all, changed, tmpDir);
+      expect(hasEmptyBumpFile).toBe(true);
+    });
+
+    test('does not detect deleted bump file as empty', async () => {
+      // empty-one.md does NOT exist on disk (was deleted)
+      const all = [makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }])];
+      const changed = ['.bumpy/change-a.md', '.bumpy/empty-one.md'];
+
+      const { hasEmptyBumpFile } = filterBranchBumpFiles(all, changed, tmpDir);
+      expect(hasEmptyBumpFile).toBe(false);
+    });
+
+    test('does not flag non-empty bump files as empty', async () => {
+      const all = [makeBumpFile('change-a', [{ name: 'pkg-a', type: 'minor' }])];
+      const changed = ['.bumpy/change-a.md'];
+
+      const { hasEmptyBumpFile } = filterBranchBumpFiles(all, changed, tmpDir);
+      expect(hasEmptyBumpFile).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Default behavior** now only fails when no bump files exist at all (matching changesets behavior) — uncovered packages produce a warning but don't block
- **`--strict` flag** for both `bumpy check` and `bumpy ci check` — fails if any changed package is not covered by a bump file
- **`--no-fail` flag** — advisory-only mode, never exits non-zero
- **Fix** false positive "empty bump file found" when deleted bump files from other branches appear in git diff
- Uses `log.error` (stderr) when failing, `log.warn` (stdout) when not
- Removed `--fail-on-missing` from `ci check` (superseded by new flags)
- Shows existing bump file paths in check output for easy navigation
- Contextual hints: suggests `none` bump type in strict mode, `--empty` in default mode
- Updated docs: CLI reference, bump files guide, differences from changesets, README

## Test plan
- [x] All existing tests pass
- [x] `bumpy check` warns about uncovered packages but exits 0 (default)
- [x] `bumpy check --strict` would exit 1 for uncovered packages
- [x] Deleted bump files from other branches no longer trigger false "empty bump file" detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)