### PR TITLE
Fix PR diff links and preserve workspace shorthand deps

### DIFF
--- a/.bumpy/fix-pr-links-and-workspace-shorthand.md
+++ b/.bumpy/fix-pr-links-and-workspace-shorthand.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix PR diff links to use full absolute URLs with `/changes` path and sha256 anchors. Preserve `workspace:^`, `workspace:~`, and `workspace:*` shorthand ranges during versioning instead of resolving them.

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -377,10 +377,11 @@ async function createVersionPr(
   pushWithToken(rootDir, branch, config);
 
   // Create or update PR
-  const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs);
+  const repo = process.env.GITHUB_REPOSITORY;
 
   if (existingPr) {
     const validPr = validatePrNumber(existingPr);
+    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, validPr);
     log.step(`Updating existing PR #${validPr}...`);
     await withPatToken(!!patPr, () =>
       runArgsAsync(['gh', 'pr', 'edit', validPr, '--title', config.versionPr.title, '--body-file', '-'], {
@@ -392,6 +393,8 @@ async function createVersionPr(
   } else {
     log.step('Creating version PR...');
     const prTitle = config.versionPr.title;
+    // Create PR first without diff links, then update body with correct PR number
+    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, null);
     const result = await withPatToken(!!patPr, () =>
       runArgsAsync(
         ['gh', 'pr', 'create', '--title', prTitle, '--body-file', '-', '--base', baseBranch, '--head', branch],
@@ -399,6 +402,21 @@ async function createVersionPr(
       ),
     );
     log.success(`🐸 Created PR: ${result}`);
+
+    // Update body now that we know the PR number
+    if (repo) {
+      const newPrNumber = result?.match(/\/pull\/(\d+)/)?.[1];
+      if (newPrNumber) {
+        const updatedBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, newPrNumber);
+        await withPatToken(!!patPr, () =>
+          runArgsAsync(['gh', 'pr', 'edit', newPrNumber, '--body-file', '-'], {
+            cwd: rootDir,
+            input: updatedBody,
+          }),
+        );
+      }
+    }
+
     if (!patPr) {
       // Push again with the custom token now that the PR exists, so that a
       // `pull_request: synchronize` event is generated and CI workflows trigger.
@@ -479,7 +497,9 @@ function formatReleasePlanComment(
     const filename = `${bf.id}.md`;
     const parts: string[] = [`\`${filename}\``];
     if (repo) {
-      parts.push(`([view diff](https://github.com/${repo}/pull/${prNumber}/files#diff-.bumpy/${filename}))`);
+      parts.push(
+        `([view diff](https://github.com/${repo}/pull/${prNumber}/changes#diff-${sha256Hex(`.bumpy/${filename}`)}))`,
+      );
       if (prBranch) {
         parts.push(`([edit](https://github.com/${repo}/edit/${prBranch}/.bumpy/${filename}))`);
       }
@@ -542,22 +562,25 @@ function bumpSectionHeader(type: string): string {
 }
 
 /** Build inline diff links for a package's changed files in the PR */
-function buildDiffLinks(pkgDir: string): string {
-  const pkgJsonPath = `${pkgDir}/package.json`;
+function buildDiffLinks(pkgDir: string, changesBaseUrl: string | null): string {
+  if (!changesBaseUrl) return '';
   const changelogPath = `${pkgDir}/CHANGELOG.md`;
   // GitHub anchors diff sections with #diff-<sha256 of file path>
-  const links = [
-    `[package.json](#diff-${sha256Hex(pkgJsonPath)})`,
-    `[CHANGELOG.md](#diff-${sha256Hex(changelogPath)})`,
-  ];
-  return ` <sub>${links.join(' · ')}</sub>`;
+  return ` <sub>[CHANGELOG.md](${changesBaseUrl}#diff-${sha256Hex(changelogPath)})</sub>`;
 }
 
 function sha256Hex(input: string): string {
   return createHash('sha256').update(input).digest('hex');
 }
 
-function formatVersionPrBody(plan: ReleasePlan, preamble: string, packageDirs: Map<string, string>): string {
+function formatVersionPrBody(
+  plan: ReleasePlan,
+  preamble: string,
+  packageDirs: Map<string, string>,
+  repo: string | undefined,
+  prNumber: string | null,
+): string {
+  const changesBaseUrl = repo && prNumber ? `https://github.com/${repo}/pull/${prNumber}/changes` : null;
   const lines: string[] = [];
   lines.push(preamble);
   lines.push('');
@@ -576,7 +599,7 @@ function formatVersionPrBody(plan: ReleasePlan, preamble: string, packageDirs: M
     for (const r of releases) {
       const suffix = r.isDependencyBump ? ' _(dep)_' : r.isCascadeBump ? ' _(cascade)_' : '';
       const pkgDir = packageDirs.get(r.name);
-      const diffLinks = pkgDir ? buildDiffLinks(pkgDir) : '';
+      const diffLinks = pkgDir ? buildDiffLinks(pkgDir, changesBaseUrl) : '';
       lines.push(`#### \`${r.name}\` ${r.oldVersion} → **${r.newVersion}**${suffix}${diffLinks}`);
       lines.push('');
 
@@ -585,7 +608,9 @@ function formatVersionPrBody(plan: ReleasePlan, preamble: string, packageDirs: M
       if (relevantBumpFiles.length > 0) {
         for (const bf of relevantBumpFiles) {
           if (bf.summary) {
-            const bfLink = ` ([bump file](#diff-${sha256Hex(`.bumpy/${bf.id}.md`)}))`;
+            const bfLink = changesBaseUrl
+              ? ` ([bump file](${changesBaseUrl}#diff-${sha256Hex(`.bumpy/${bf.id}.md`)}))`
+              : '';
             const summaryLines = bf.summary.split('\n');
             lines.push(`- ${summaryLines[0]}${bfLink}`);
             for (let i = 1; i < summaryLines.length; i++) {

--- a/packages/bumpy/src/core/apply-release-plan.ts
+++ b/packages/bumpy/src/core/apply-release-plan.ts
@@ -85,9 +85,9 @@ function updateRange(range: string, newVersion: string): string {
   const prefixMatch = cleanRange.match(/^(\^|~|>=|>|<=|<|=)?/);
   const prefix = prefixMatch?.[1] ?? '^';
 
-  // Handle wildcard ranges
-  if (cleanRange === '*' || cleanRange === '') {
-    return range; // don't touch wildcards
+  // Handle wildcard ranges and workspace shorthand (workspace:^, workspace:~, workspace:*)
+  if (cleanRange === '*' || cleanRange === '' || cleanRange === '^' || cleanRange === '~') {
+    return range; // don't touch wildcards or workspace shorthands
   }
 
   return `${protocol}${prefix}${newVersion}`;

--- a/packages/bumpy/test/core/apply-release-plan.test.ts
+++ b/packages/bumpy/test/core/apply-release-plan.test.ts
@@ -230,6 +230,59 @@ describe('applyReleasePlan', () => {
     expect(deps.core).toBe('workspace:^2.0.0');
   });
 
+  test('preserves workspace shorthand (workspace:^, workspace:~, workspace:*)', async () => {
+    const coreDir = await setupPackage('core', '1.0.0');
+    const appDir = await setupPackage('app', '1.0.0', {
+      dependencies: { core: 'workspace:*' },
+      devDependencies: { core: 'workspace:^' },
+      peerDependencies: { core: 'workspace:~' },
+    });
+
+    const packages = new Map<string, WorkspacePackage>();
+    packages.set('core', {
+      name: 'core',
+      version: '1.0.0',
+      dir: coreDir,
+      relativeDir: 'packages/core',
+      packageJson: { name: 'core', version: '1.0.0' },
+      private: false,
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+      optionalDependencies: {},
+    });
+    packages.set('app', {
+      name: 'app',
+      version: '1.0.0',
+      dir: appDir,
+      relativeDir: 'packages/app',
+      packageJson: {
+        name: 'app',
+        version: '1.0.0',
+        dependencies: { core: 'workspace:*' },
+        devDependencies: { core: 'workspace:^' },
+        peerDependencies: { core: 'workspace:~' },
+      },
+      private: false,
+      dependencies: { core: 'workspace:*' },
+      devDependencies: { core: 'workspace:^' },
+      peerDependencies: { core: 'workspace:~' },
+      optionalDependencies: {},
+    });
+
+    const coreRelease = makeRelease('core', '2.0.0', { type: 'major', oldVersion: '1.0.0' });
+    const appRelease = makeRelease('app', '1.0.1', { oldVersion: '1.0.0', isDependencyBump: true });
+
+    await ensureDir(resolve(tmpDir, '.bumpy'));
+
+    await applyReleasePlan(makeReleasePlan([coreRelease, appRelease]), packages, tmpDir, makeConfig());
+
+    const appPkg = await readJson<Record<string, unknown>>(resolve(appDir, 'package.json'));
+    expect((appPkg.dependencies as Record<string, string>).core).toBe('workspace:*');
+    expect((appPkg.devDependencies as Record<string, string>).core).toBe('workspace:^');
+    expect((appPkg.peerDependencies as Record<string, string>).core).toBe('workspace:~');
+  });
+
   test('preserves package.json formatting when bumping version', async () => {
     // Write a package.json with custom formatting (inline arrays, tab indent, etc.)
     const pkgDir = resolve(tmpDir, 'packages/pkg-a');


### PR DESCRIPTION
## Summary
- Fix all PR diff links (version PR body + PR comments) to use full absolute URLs with `/changes` path and `sha256` anchors, so they work when clicked from the conversation tab
- Remove package.json link from version PR diff links (only link CHANGELOG.md)
- For new version PRs, update the body after creation to backfill links with the correct PR number
- Preserve `workspace:^`, `workspace:~`, and `workspace:*` shorthand ranges during versioning instead of resolving them to explicit versions

## Test plan
- [x] Existing tests pass (196 pass, 0 fail)
- [x] New test for workspace shorthand preservation
- [ ] Verify diff links work on a real version PR