### PR TITLE
Remove --pat-pr and --pat-comments flags, auto-detect BUMPY_GH_TOKEN

### DIFF
--- a/.bumpy/remove-pat-flags.md
+++ b/.bumpy/remove-pat-flags.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Remove --pat-pr and --pat-comments flags; BUMPY_GH_TOKEN is now auto-detected for PR operations and comments always use the default token (fixes fork PR support)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,6 @@ jobs:
       # -------------------------------
 
       # 🐸 This is the important part - checks for missing bump files and posts/updates a PR comment with the release plan
-      # (use --pat-comments if PAT belongs to dedicated bot, rather than person)
-      - run: bunx @varlock/bumpy ci check --pat-comments
+      - run: bunx @varlock/bumpy ci check
         env:
           GH_TOKEN: ${{ github.token }}
-          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # <- PAT needed so that release PR will trigger CI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,7 @@ jobs:
       # -------------------------------
 
       # 🐸 This is the important part - creates/updates release PR when PRs merge to main, publishes packages when release PR is merged
-      # (use --pat-pr if PAT belongs to dedicated bot, rather than person)
-      - run: bunx @varlock/bumpy ci release --pat-pr
+      - run: bunx @varlock/bumpy ci release
         env:
           GH_TOKEN: ${{ github.token }}
-          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # <- PAT needed so that release PR will trigger CI
+          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # <- PAT so that version PR triggers CI

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ jobs:
       - run: bunx @varlock/bumpy ci check
         env:
           GH_TOKEN: ${{ github.token }}
-          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # additional PAT (optional)
 ```
 
 ### Release workflow
@@ -135,7 +134,7 @@ jobs:
       - run: bunx @varlock/bumpy ci release
         env:
           GH_TOKEN: ${{ github.token }}
-          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # additional PAT, needed to trigger CI checks on release PR
+          BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # PAT so that version PR triggers CI
 ```
 
 > **Trusted publishing setup:** Configure each package on [npmjs.com](https://docs.npmjs.com/trusted-publishers/) → Package Settings → Trusted Publishers → GitHub Actions. Specify your org/user, repo, and the workflow filename (`bumpy-release.yml`). No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1 - bumpy will warn if your version is too old.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,14 +148,13 @@ bumpy ci check --strict
 bumpy ci check --no-fail
 ```
 
-| Flag             | Description                                                      |
-| ---------------- | ---------------------------------------------------------------- |
-| `--comment`      | Force PR comment on or off (default: auto-detect CI environment) |
-| `--strict`       | Fail if any changed package is not covered by a bump file        |
-| `--no-fail`      | Warn only, never exit non-zero                                   |
-| `--pat-comments` | Post PR comments using `BUMPY_GH_TOKEN` instead of `GH_TOKEN`    |
+| Flag        | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| `--comment` | Force PR comment on or off (default: auto-detect CI environment) |
+| `--strict`  | Fail if any changed package is not covered by a bump file        |
+| `--no-fail` | Warn only, never exit non-zero                                   |
 
-Requires `GH_TOKEN` environment variable. The `--pat-comments` flag requires `BUMPY_GH_TOKEN` — use it when the token belongs to a dedicated automation account (bot user). If you're using a developer's personal PAT, leave this off so comments appear from `github-actions[bot]`.
+Requires `GH_TOKEN` environment variable (automatically available in GitHub Actions).
 
 ## `bumpy ci release`
 
@@ -176,9 +175,8 @@ bumpy ci release --auto-publish --tag beta
 | `--auto-publish`  | Version + publish directly instead of creating a PR        |
 | `--tag <tag>`     | npm dist-tag (for `--auto-publish`)                        |
 | `--branch <name>` | Version PR branch name (default: `bumpy/version-packages`) |
-| `--pat-pr`        | Create/edit the version PR using `BUMPY_GH_TOKEN`          |
 
-Requires `GH_TOKEN`. Optionally uses `BUMPY_GH_TOKEN` to push the version branch so PR workflows trigger (see [GitHub Actions setup](github-actions.md#token-setup)). The `--pat-pr` flag additionally uses `BUMPY_GH_TOKEN` to create/edit the PR itself — use it when the token belongs to a dedicated automation account (bot user). If you're using a developer's personal PAT, leave this off so the PR is authored by `github-actions[bot]` and the developer can still approve it.
+Requires `GH_TOKEN`. When `BUMPY_GH_TOKEN` is set, it is automatically used to push the version branch and create/edit the PR so that PR workflows trigger (see [GitHub Actions setup](github-actions.md#token-setup)).
 
 ## `bumpy ci setup`
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -123,18 +123,9 @@ GitHub's anti-recursion guard prevents PRs created by the default `github.token`
 
 To fix this, provide a `BUMPY_GH_TOKEN` using either a **fine-grained PAT** or a **GitHub App token**. Bumpy uses this token to push the version branch, which allows your CI workflows to trigger normally.
 
-#### Controlling what the token is used for
+When `BUMPY_GH_TOKEN` is set, bumpy automatically uses it for git push operations and for creating/editing the version PR. PR comments always use the default `GH_TOKEN` so they appear from `github-actions[bot]`.
 
-By default, `BUMPY_GH_TOKEN` is only used for git push operations. You can opt in to using it for other GitHub API calls:
-
-| Flag             | Command      | Effect                                        |
-| ---------------- | ------------ | --------------------------------------------- |
-| `--pat-pr`       | `ci release` | Create/edit the version PR as the token owner |
-| `--pat-comments` | `ci check`   | Post PR comments as the token owner           |
-
-**When to use these flags:** Use them when `BUMPY_GH_TOKEN` belongs to a dedicated automation account (bot user or GitHub App). The PR and comments will appear from that account.
-
-**When NOT to use these flags:** If you're using a developer's personal PAT, leave these off. PRs and comments will appear from `github-actions[bot]`, which allows the developer to still review and approve the PR.
+> **Note:** If you're using a developer's personal PAT, the version PR will be authored by that developer. Consider using a dedicated bot account or GitHub App so the developer can still review and approve the PR.
 
 Run `bumpy ci setup` for interactive guidance, or set it up manually:
 

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -104,7 +104,6 @@ async function main() {
             comment: ciFlags.comment !== undefined ? ciFlags.comment === true : undefined,
             strict: ciFlags.strict === true,
             noFail: ciFlags['no-fail'] === true,
-            patComments: ciFlags['pat-comments'] === true,
           });
         } else if (subcommand === 'release') {
           const { ciReleaseCommand } = await import('./commands/ci.ts');
@@ -113,7 +112,6 @@ async function main() {
             mode,
             tag: ciFlags.tag as string | undefined,
             branch: ciFlags.branch as string | undefined,
-            patPr: ciFlags['pat-pr'] === true,
           });
         } else if (subcommand === 'setup') {
           const { ciSetupCommand } = await import('./commands/ci-setup.ts');

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -18,23 +18,14 @@ import type { BumpyConfig, BumpFile, PackageManager, ReleasePlan, PlannedRelease
 /**
  * Temporarily override GH_TOKEN with BUMPY_GH_TOKEN for a gh CLI call.
  *
- * Use `--pat-pr` / `--pat-comments` flags to opt in. This is useful when
- * BUMPY_GH_TOKEN belongs to a dedicated automation/bot account. If you're
- * using a developer's personal PAT, it's better to leave these flags off so
- * that PRs and comments appear from github-actions[bot] — allowing the
- * developer to still review and approve the PR.
+ * When BUMPY_GH_TOKEN is set (e.g. a dedicated bot PAT or GitHub App token),
+ * it is used so that PRs created by bumpy can trigger CI workflows (the
+ * default GITHUB_TOKEN cannot do this). If BUMPY_GH_TOKEN is not available
+ * (e.g. fork PRs where secrets are hidden), falls back to the default token.
  */
-function requirePatToken(): string {
+async function withPatToken<T>(fn: () => Promise<T>): Promise<T> {
   const token = process.env.BUMPY_GH_TOKEN;
-  if (!token) {
-    throw new Error('BUMPY_GH_TOKEN must be set when using --pat-pr or --pat-comments');
-  }
-  return token;
-}
-
-async function withPatToken<T>(usePat: boolean, fn: () => Promise<T>): Promise<T> {
-  if (!usePat) return fn();
-  const token = requirePatToken();
+  if (!token) return fn();
   const originalGhToken = process.env.GH_TOKEN;
   process.env.GH_TOKEN = token;
   try {
@@ -83,7 +74,6 @@ interface CheckOptions {
   comment?: boolean; // post a PR comment via gh (default: true in CI)
   strict?: boolean; // exit 1 if any changed packages are uncovered
   noFail?: boolean; // never exit 1, warn only
-  patComments?: boolean; // post PR comments using BUMPY_GH_TOKEN
 }
 
 /**
@@ -134,7 +124,6 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
           prNumber,
           formatEmptyBumpFileComment(emptyBumpFileIds, prNumber, prBranch),
           rootDir,
-          opts.patComments,
         );
       }
       return;
@@ -156,7 +145,6 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
           ? formatBumpFileErrorsComment(parseErrors, prBranch, pm)
           : formatNoBumpFilesComment(prBranch, pm),
         rootDir,
-        opts.patComments,
       );
     }
 
@@ -191,7 +179,7 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
       parseErrors,
       emptyBumpFileIds,
     );
-    await postOrUpdatePrComment(prNumber, comment, rootDir, opts.patComments);
+    await postOrUpdatePrComment(prNumber, comment, rootDir);
   }
 
   // Fail if there were parse errors (even if some files parsed successfully)
@@ -217,7 +205,6 @@ interface ReleaseOptions {
   mode: 'auto-publish' | 'version-pr';
   tag?: string; // npm dist-tag for auto-publish
   branch?: string; // branch name for version PR (default: "bumpy/version-packages")
-  patPr?: boolean; // create/edit PR using BUMPY_GH_TOKEN
 }
 
 /**
@@ -257,7 +244,7 @@ export async function ciReleaseCommand(rootDir: string, opts: ReleaseOptions): P
     await autoPublish(rootDir, config, plan, opts.tag);
   } else {
     const packageDirs = new Map([...packages.values()].map((p) => [p.name, p.relativeDir]));
-    await createVersionPr(rootDir, plan, config, packageDirs, opts.branch, opts.patPr);
+    await createVersionPr(rootDir, plan, config, packageDirs, opts.branch);
   }
 }
 
@@ -382,7 +369,6 @@ async function createVersionPr(
   config: BumpyConfig,
   packageDirs: Map<string, string>,
   branchName?: string,
-  patPr?: boolean,
 ): Promise<void> {
   const branch = validateBranchName(branchName || config.versionPr.branch);
   const baseBranch = validateBranchName(
@@ -426,12 +412,13 @@ async function createVersionPr(
 
   // Create or update PR
   const repo = process.env.GITHUB_REPOSITORY;
+  const noPatWarning = !process.env.BUMPY_GH_TOKEN && !!repo;
 
   if (existingPr) {
     const validPr = validatePrNumber(existingPr);
-    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, validPr);
+    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, validPr, noPatWarning);
     log.step(`Updating existing PR #${validPr}...`);
-    await withPatToken(!!patPr, () =>
+    await withPatToken(() =>
       runArgsAsync(['gh', 'pr', 'edit', validPr, '--title', config.versionPr.title, '--body-file', '-'], {
         cwd: rootDir,
         input: prBody,
@@ -442,8 +429,8 @@ async function createVersionPr(
     log.step('Creating version PR...');
     const prTitle = config.versionPr.title;
     // Create PR first without diff links, then update body with correct PR number
-    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, null);
-    const result = await withPatToken(!!patPr, () =>
+    const prBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, null, noPatWarning);
+    const result = await withPatToken(() =>
       runArgsAsync(
         ['gh', 'pr', 'create', '--title', prTitle, '--body-file', '-', '--base', baseBranch, '--head', branch],
         { cwd: rootDir, input: prBody },
@@ -455,8 +442,15 @@ async function createVersionPr(
     if (repo) {
       const newPrNumber = result?.match(/\/pull\/(\d+)/)?.[1];
       if (newPrNumber) {
-        const updatedBody = formatVersionPrBody(plan, config.versionPr.preamble, packageDirs, repo, newPrNumber);
-        await withPatToken(!!patPr, () =>
+        const updatedBody = formatVersionPrBody(
+          plan,
+          config.versionPr.preamble,
+          packageDirs,
+          repo,
+          newPrNumber,
+          noPatWarning,
+        );
+        await withPatToken(() =>
           runArgsAsync(['gh', 'pr', 'edit', newPrNumber, '--body-file', '-'], {
             cwd: rootDir,
             input: updatedBody,
@@ -465,7 +459,7 @@ async function createVersionPr(
       }
     }
 
-    if (!patPr) {
+    if (!process.env.BUMPY_GH_TOKEN) {
       // Push again with the custom token now that the PR exists, so that a
       // `pull_request: synchronize` event is generated and CI workflows trigger.
       // (The initial push happened before the PR existed, and the PR creation
@@ -708,6 +702,7 @@ function formatVersionPrBody(
   packageDirs: Map<string, string>,
   repo: string | undefined,
   prNumber: string | null,
+  showNoPatWarning = false,
 ): string {
   const changesBaseUrl = repo && prNumber ? `https://github.com/${repo}/pull/${prNumber}/changes` : null;
   const lines: string[] = [];
@@ -759,12 +754,19 @@ function formatVersionPrBody(
     }
   }
 
+  if (showNoPatWarning) {
+    lines.push(
+      '> ⚠️ `BUMPY_GH_TOKEN` is not set — CI checks will not run automatically on this PR. Run `bumpy ci setup` for help.',
+    );
+    lines.push('');
+  }
+
   return lines.join('\n');
 }
 
 const COMMENT_MARKER = '<!-- bumpy-release-plan -->';
 
-async function postOrUpdatePrComment(prNumber: string, body: string, rootDir: string, usePat = false): Promise<void> {
+async function postOrUpdatePrComment(prNumber: string, body: string, rootDir: string): Promise<void> {
   const validPr = validatePrNumber(prNumber);
   const markedBody = `${COMMENT_MARKER}\n${body}`;
 
@@ -779,17 +781,16 @@ async function postOrUpdatePrComment(prNumber: string, body: string, rootDir: st
     const commentId = existingComment?.split('\n')[0]?.trim();
 
     if (commentId) {
-      await withPatToken(usePat, () =>
-        runArgsAsync(
-          ['gh', 'api', `repos/{owner}/{repo}/issues/comments/${commentId}`, '-X', 'PATCH', '-F', 'body=@-'],
-          { cwd: rootDir, input: markedBody },
-        ),
+      await runArgsAsync(
+        ['gh', 'api', `repos/{owner}/{repo}/issues/comments/${commentId}`, '-X', 'PATCH', '-F', 'body=@-'],
+        { cwd: rootDir, input: markedBody },
       );
       log.dim('  Updated PR comment');
     } else {
-      await withPatToken(usePat, () =>
-        runArgsAsync(['gh', 'pr', 'comment', validPr, '--body-file', '-'], { cwd: rootDir, input: markedBody }),
-      );
+      await runArgsAsync(['gh', 'pr', 'comment', validPr, '--body-file', '-'], {
+        cwd: rootDir,
+        input: markedBody,
+      });
       log.dim('  Posted PR comment');
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

- Remove `--pat-pr` and `--pat-comments` CLI flags — `BUMPY_GH_TOKEN` is now automatically used for PR operations when set
- PR comments always use the default `GH_TOKEN`, which fixes commenting on fork PRs (where secrets are unavailable)
- Version PR body shows a warning when `BUMPY_GH_TOKEN` is missing, since CI won't trigger automatically
- Updated docs and workflow files

This is a minor breaking change since the flags are removed, but they'll just be silently ignored by the flag parser if anyone still passes them.