### PR TITLE
Fix `none` bump type semantics and add hook-aware `bumpy check`

### DIFF
--- a/.bumpy/none-semantics-and-check-hooks.md
+++ b/.bumpy/none-semantics-and-check-hooks.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Changed `none` bump type to no longer suppress cascading bumps. Added `--hook` flag to `bumpy check` for pre-commit/pre-push hook context, with untracked/staged bump file detection.

--- a/.bumpy/none-semantics-and-check-hooks.md
+++ b/.bumpy/none-semantics-and-check-hooks.md
@@ -2,4 +2,4 @@
 '@varlock/bumpy': minor
 ---
 
-Changed `none` bump type to no longer suppress cascading bumps. Added `--hook` flag to `bumpy check` for pre-commit/pre-push hook context, with untracked/staged bump file detection.
+Changed `none` bump type to no longer suppress cascading bumps — it now just skips the direct bump while allowing dependency propagation to apply normally. Added `--hook` flag to `bumpy check` for pre-commit/pre-push hook context, with untracked/staged bump file detection. Added `bumpy add --none` shortcut to acknowledge all changed packages without bumping. Empty bump files no longer bypass `--strict` mode.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A modern package versioning, release, and changelog generation tool. Built for m
 Bumpy uses **bump files** (you may know them as "changesets" if coming from [that tool 🦋](https://github.com/changesets/changesets)) - small markdown files that declare an intent to release packages with a bump level (patch/minor/major), and a description that ends up in changelogs. Developers create these files as part of their PRs, and these files are then used to consolidate changes, generate changelogs, and trigger publishing. Specifically:
 
 - Devs/agents create bump files as part of their PRs (using `bumpy add` or manually)
-- A pre-push git hook can enforce bump files exist for changed packages
+- A git hook (pre-commit or pre-push) can enforce bump files exist for changed packages
 - In CI, a workflow checks PRs for bump files, leaves a comment on the PR detailing changed packages
 - As PRs merge to the base branch, a "release PR" is kept up to date
   - Shows what packages will be released and their changelogs

--- a/docs/bump-files.md
+++ b/docs/bump-files.md
@@ -66,6 +66,7 @@ Flags:
 - `--message <text>` — changelog description
 - `--name <name>` — set the filename (auto-slugified). If omitted, a random name is generated.
 - `--empty` — create an empty bump file (marks a PR as intentionally having no releases)
+- `--none` — create a bump file with all changed packages set to `none` (acknowledge without bumping)
 
 ### From branch commits
 
@@ -101,6 +102,12 @@ Use bump type `none` to acknowledge that a package changed without triggering a 
 ```
 
 This covers the package in `bumpy check` (including `--strict` mode) without producing a version bump or changelog entry. However, if another package's bump cascades to this package (e.g., via dependency propagation), the cascade will still apply normally.
+
+To quickly set all changed packages to `none`:
+
+```bash
+bumpy add --none
+```
 
 ## Cascade control (advanced)
 

--- a/docs/bump-files.md
+++ b/docs/bump-files.md
@@ -24,12 +24,12 @@ Fixed locale fallback logic in utils.
 
 ### Bump levels
 
-| Level   | When to use                                                                                                                                                        |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `major` | Breaking changes                                                                                                                                                   |
-| `minor` | New features (backwards-compatible)                                                                                                                                |
-| `patch` | Bug fixes, minor improvements                                                                                                                                      |
-| `none`  | Acknowledges a change without triggering a release — useful for covering packages in `--strict` mode, or in cascades to exclude specific packages from propagation |
+| Level   | When to use                                                                                                                                                    |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `major` | Breaking changes                                                                                                                                               |
+| `minor` | New features (backwards-compatible)                                                                                                                            |
+| `patch` | Bug fixes, minor improvements                                                                                                                                  |
+| `none`  | Acknowledges a change without triggering a direct bump — useful for covering packages in `--strict` mode. Cascading bumps from other packages can still apply. |
 
 ## File naming
 
@@ -92,7 +92,7 @@ This prevents `bumpy check` and `bumpy ci check` from failing due to missing bum
 
 ### `none` bump type
 
-If you're using `--strict` mode (which requires every changed package to be covered), use bump type `none` to acknowledge a package changed without triggering a release:
+Use bump type `none` to acknowledge that a package changed without triggering a direct version bump. This is useful when a package has internal-only changes (tests, config, etc.) that don't warrant a release on their own:
 
 ```markdown
 ---
@@ -100,7 +100,7 @@ If you're using `--strict` mode (which requires every changed package to be cove
 ---
 ```
 
-This covers the package in strict checks without producing a version bump or changelog entry.
+This covers the package in `bumpy check` (including `--strict` mode) without producing a version bump or changelog entry. However, if another package's bump cascades to this package (e.g., via dependency propagation), the cascade will still apply normally.
 
 ## Cascade control (advanced)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,14 +23,16 @@ Create a bump file interactively or non-interactively.
 bumpy add                                                # interactive
 bumpy add --packages "core:minor,utils:patch" --message "Added features"  # non-interactive
 bumpy add --empty --name "docs-only-pr"                  # empty (no releases)
+bumpy add --none                                         # all changed packages → none
 ```
 
-| Flag                | Description                                                                |
-| ------------------- | -------------------------------------------------------------------------- |
-| `--packages <list>` | Comma-separated `name:level` pairs                                         |
-| `--message <text>`  | Changelog description                                                      |
-| `--name <name>`     | Bump file filename (auto-slugified)                                        |
-| `--empty`           | Create an empty bump file (marks a PR as intentionally having no releases) |
+| Flag                | Description                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| `--packages <list>` | Comma-separated `name:level` pairs                                                    |
+| `--message <text>`  | Changelog description                                                                 |
+| `--name <name>`     | Bump file filename (auto-slugified)                                                   |
+| `--empty`           | Create an empty bump file (marks a PR as intentionally having no releases)            |
+| `--none`            | Set all changed packages to `none` (acknowledge without bumping, for `--strict` mode) |
 
 ## `bumpy status`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,7 @@ bumpy publish --filter "@myorg/*"
 
 ## `bumpy check`
 
-Verify that changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages.
+Verify that changed packages on the current branch have corresponding bump files. Compares your branch to the base branch, maps changed files to packages, and checks for matching bump files.
 
 By default, exits non-zero only if **no** bump files exist at all (matching changesets behavior). Use `--strict` to require every changed package to be covered.
 
@@ -103,12 +103,27 @@ By default, exits non-zero only if **no** bump files exist at all (matching chan
 bumpy check
 bumpy check --strict
 bumpy check --no-fail
+bumpy check --hook pre-commit
+bumpy check --hook pre-push
 ```
 
-| Flag        | Description                                                |
-| ----------- | ---------------------------------------------------------- |
-| `--strict`  | Fail if any changed package is not covered by a bump file  |
-| `--no-fail` | Warn only, never exit non-zero (useful for advisory hooks) |
+| Flag                | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `--strict`          | Fail if any changed package is not covered by a bump file  |
+| `--no-fail`         | Warn only, never exit non-zero (useful for advisory hooks) |
+| `--hook pre-commit` | Only count staged + committed bump files                   |
+| `--hook pre-push`   | Only count committed bump files                            |
+
+### Hook context
+
+By default (no `--hook` flag), bumpy detects all bump files — including untracked and staged files that haven't been committed yet. This is convenient when running `bumpy check` manually.
+
+When used as a git hook, `--hook` controls which bump files count:
+
+- **`--hook pre-commit`** — staged and committed bump files count. Untracked bump files are warned about (they won't be included in the commit).
+- **`--hook pre-push`** — only committed bump files count. Staged and untracked bump files are warned about (they won't be included in the push).
+
+The output also annotates bump files with their git status (`staged`, `untracked`) so you can see at a glance what's been committed.
 
 No GitHub API needed.
 

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -158,7 +158,7 @@ Bumpy replaces all of this with two CLI commands you run directly in standard wo
 
 ### Local bump file verification
 
-`bumpy check` verifies that changed packages on the current branch have corresponding bump files. Designed for pre-push hooks — compares your branch to the base branch, maps changed files to packages. By default it only fails if no bump files exist at all (matching changesets behavior). Use `--strict` to require every changed package to be covered, or `--no-fail` for advisory-only mode. No GitHub API needed.
+`bumpy check` verifies that changed packages on the current branch have corresponding bump files. Compares your branch to the base branch, maps changed files to packages. By default it only fails if no bump files exist at all (matching changesets behavior). Use `--strict` to require every changed package to be covered, `--no-fail` for advisory-only mode, or `--hook pre-commit`/`--hook pre-push` to control which bump files count based on their git status. No GitHub API needed.
 
 Changesets has no built-in equivalent — users rely on the CI bot comment to catch missing bump files after pushing.
 

--- a/docs/version-propagation.md
+++ b/docs/version-propagation.md
@@ -163,7 +163,7 @@ Unlike dependency bump rules (configured on the _dependent_), `cascadeTo` is con
 
 These are set directly in bump files for one-off control over a specific release.
 
-**`none`** — suppresses a bump on a package that would otherwise be included via propagation. If skipping the bump would leave a dependent's range broken, bumpy throws an error.
+**`none`** — acknowledges a change without triggering a direct bump. Unlike a real bump type, `none` doesn't add the package to the release plan on its own. However, cascading bumps from other packages (e.g., out-of-range or proactive propagation) can still bump it normally.
 
 ```yaml
 ---

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,4 +12,4 @@ pre-commit:
 pre-push:
   jobs:
     - name: bumpy-check
-      run: bunx @varlock/bumpy check
+      run: bunx @varlock/bumpy check --hook pre-push

--- a/packages/bumpy/skills/add-change/SKILL.md
+++ b/packages/bumpy/skills/add-change/SKILL.md
@@ -43,7 +43,7 @@ For each affected package, choose the appropriate bump level:
 | **minor** | New features: added exports, new options, new functionality                             |
 | **patch** | Bug fixes, internal refactors, documentation, dependency updates                        |
 
-Use `none` in a bump file to suppress a bump on a package that would otherwise be included via propagation. If skipping would leave a broken range, bumpy throws an error.
+Use `none` in a bump file to acknowledge a change without triggering a direct bump. Cascading bumps from other packages can still apply normally.
 
 ### 4. Write a clear summary
 

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -46,6 +46,7 @@ async function main() {
           message: flags.message as string | undefined,
           name: flags.name as string | undefined,
           empty: flags.empty === true,
+          none: flags.none === true,
         });
         break;
       }
@@ -190,6 +191,8 @@ function printHelp() {
   Commands:
     init [--force]          Initialize .bumpy/ (migrates from .changeset/ if found)
     add                     Create a new bump file
+      --none                  Set all changed packages to "none" (acknowledge without bumping)
+      --empty                 Create an empty bump file (no releases needed)
     generate                Generate bump file from branch commits
     status                  Show pending releases
     check                   Verify changed packages have bump files (for git hooks)

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -86,9 +86,15 @@ async function main() {
       case 'check': {
         const rootDir = await findRoot();
         const { checkCommand } = await import('./commands/check.ts');
+        const hookValue = flags.hook as string | undefined;
+        if (hookValue && hookValue !== 'pre-commit' && hookValue !== 'pre-push') {
+          log.error(`Invalid --hook value "${hookValue}". Expected "pre-commit" or "pre-push".`);
+          process.exit(1);
+        }
         await checkCommand(rootDir, {
           strict: flags.strict === true,
           noFail: flags['no-fail'] === true,
+          hook: hookValue as 'pre-commit' | 'pre-push' | undefined,
         });
         break;
       }
@@ -186,9 +192,10 @@ function printHelp() {
     add                     Create a new bump file
     generate                Generate bump file from branch commits
     status                  Show pending releases
-    check                   Verify changed packages have bump files (for pre-push hooks)
+    check                   Verify changed packages have bump files (for git hooks)
       --strict                Fail if any changed package is uncovered (default: only fail if no bump files at all)
       --no-fail               Warn only, never exit 1
+      --hook <context>        Hook context: "pre-commit" or "pre-push" (controls which bump files count)
     version [--commit]      Apply bump files and bump versions
     publish                 Publish versioned packages
     ci check                PR check — report pending releases, comment on PR

--- a/packages/bumpy/src/commands/add.ts
+++ b/packages/bumpy/src/commands/add.ts
@@ -7,7 +7,8 @@ import { randomName, slugify } from '../utils/names.ts';
 import { writeBumpFile } from '../core/bump-file.ts';
 import picomatch from 'picomatch';
 import { getBumpyDir, loadConfig, loadPackageConfig, matchGlob } from '../core/config.ts';
-import { discoverPackages } from '../core/workspace.ts';
+import { discoverPackages, discoverWorkspace } from '../core/workspace.ts';
+import { findChangedPackages } from './check.ts';
 import { DependencyGraph } from '../core/dep-graph.ts';
 import { getChangedFiles } from '../core/git.ts';
 import { bumpSelectPrompt } from '../prompts/bump-select.ts';
@@ -19,6 +20,7 @@ interface AddOptions {
   message?: string;
   name?: string;
   empty?: boolean;
+  none?: boolean;
 }
 
 const CASCADE_CHOICES: { label: string; value: BumpType }[] = [
@@ -39,6 +41,34 @@ export async function addCommand(rootDir: string, opts: AddOptions): Promise<voi
     const { writeText } = await import('../utils/fs.ts');
     await writeText(filePath, '---\n---\n');
     log.success(`🐸 Created empty bump file: .bumpy/${filename}.md`);
+    return;
+  }
+
+  // Handle --none flag: create bump file with all changed packages set to none
+  if (opts.none) {
+    const { packages } = await discoverWorkspace(rootDir, config);
+    const changedFiles = getChangedFiles(rootDir, config.baseBranch);
+    const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
+
+    if (changedPackages.length === 0) {
+      log.info('No changed packages detected.');
+      return;
+    }
+
+    const releases: BumpFileRelease[] = changedPackages.map((name) => ({ name, type: 'none' as const }));
+    const summary = opts.message || '';
+    const filename = opts.name ? slugify(opts.name) : randomName();
+
+    if (await exists(resolve(bumpyDir, `${filename}.md`))) {
+      await writeBumpFile(rootDir, `${filename}-${Date.now()}`, releases, summary);
+    } else {
+      await writeBumpFile(rootDir, filename, releases, summary);
+    }
+
+    log.success(`🐸 Created bump file with ${changedPackages.length} package(s) set to none: .bumpy/${filename}.md`);
+    for (const name of changedPackages) {
+      log.dim(`  ${name}: none`);
+    }
     return;
   }
 

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -118,11 +118,7 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     }
   }
 
-  // If an empty bump file exists on this branch, the check passes
-  if (effectiveEmptyIds.length > 0) {
-    log.success('Empty bump file found — no releases needed.');
-    return;
-  }
+  const hasEmptyBumpFile = effectiveEmptyIds.length > 0;
 
   // Find which packages are covered by bump files on this branch
   const coveredPackages = new Set<string>();
@@ -139,36 +135,37 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     return;
   }
 
-  // No bump files at all — fail by default
-  const willFailNoBump = !opts.noFail;
-  if (effectiveBumpFiles.length === 0) {
-    (willFailNoBump ? log.error : log.warn)(`${changedPackages.length} changed package(s) missing bump files:\n`);
-    for (const name of changedPackages) {
-      console.log(`  ${colorize(name, 'yellow')}`);
-    }
-    console.log();
-    log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
-    log.dim('To adjust which files trigger change detection, set `changedFilePatterns` in .bumpy/_config.json.');
-    if (willFailNoBump) process.exit(1);
-    return;
-  }
-
   // Check which changed packages are missing bump files
   const missing = changedPackages.filter((name) => !coveredPackages.has(name));
 
-  if (missing.length === 0) {
-    log.success(`🐸 All ${changedPackages.length} changed package(s) have bump files.`);
-    printBumpFileList(
-      effectiveBumpFiles.map((bf) => bf.id),
-      bumpyRelDir,
-      bumpFileStatuses,
-    );
+  // An empty bump file covers all remaining packages (in non-strict mode)
+  // It acts as a blanket acknowledgment that non-publishable changes are expected
+  const hasAnyCoverage = effectiveBumpFiles.length > 0 || hasEmptyBumpFile;
+  const allCovered = missing.length === 0 || (hasEmptyBumpFile && !opts.strict);
+
+  if (allCovered) {
+    if (hasEmptyBumpFile && missing.length > 0) {
+      // Empty bump file covers remaining packages — inform the user
+      log.success('Empty bump file found — uncovered packages acknowledged.');
+    } else {
+      log.success(`🐸 All ${changedPackages.length} changed package(s) have bump files.`);
+    }
+    if (effectiveBumpFiles.length > 0) {
+      printBumpFileList(
+        effectiveBumpFiles.map((bf) => bf.id),
+        bumpyRelDir,
+        bumpFileStatuses,
+      );
+    }
     return;
   }
 
-  // Some packages uncovered — warn by default, fail with --strict
-  const willFailUncovered = opts.strict && !opts.noFail;
-  (willFailUncovered ? log.error : log.warn)(`${missing.length} changed package(s) missing bump files:\n`);
+  // Determine failure behavior
+  // - No coverage at all: fail by default (unless --no-fail)
+  // - Partial coverage: fail only with --strict (unless --no-fail)
+  const willFail = !opts.noFail && (opts.strict || !hasAnyCoverage);
+
+  (willFail ? log.error : log.warn)(`${missing.length} changed package(s) missing bump files:\n`);
   for (const name of missing) {
     console.log(`  ${colorize(name, 'yellow')}`);
   }
@@ -191,7 +188,7 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
   }
   log.dim('To adjust which files trigger change detection, set `changedFilePatterns` in .bumpy/_config.json.');
-  if (willFailUncovered) process.exit(1);
+  if (willFail) process.exit(1);
 }
 
 function printBumpFileList(

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -4,12 +4,15 @@ import { log, colorize } from '../utils/logger.ts';
 import { loadConfig, loadPackageConfig, getBumpyDir } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
-import { getChangedFiles } from '../core/git.ts';
+import { getChangedFiles, getFileStatuses } from '../core/git.ts';
 import type { BumpyConfig, WorkspacePackage } from '../types.ts';
+
+export type HookContext = 'pre-commit' | 'pre-push';
 
 interface CheckOptions {
   strict?: boolean;
   noFail?: boolean;
+  hook?: HookContext;
 }
 
 /**
@@ -20,6 +23,8 @@ interface CheckOptions {
  * Default: at least one bump file must exist, uncovered packages are warned.
  * --strict: every changed package must be covered.
  * --no-fail: warn only, never exit 1.
+ * --hook pre-commit: only staged + committed bump files count.
+ * --hook pre-push: only committed bump files count.
  */
 export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Promise<void> {
   const config = await loadConfig(rootDir);
@@ -42,17 +47,86 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     }
     process.exit(1);
   }
-  const { branchBumpFiles, emptyBumpFileIds } = filterBranchBumpFiles(allBumpFiles, changedFiles, rootDir);
+
+  // Get git status of bump files to detect untracked/staged files
+  const bumpyDir = getBumpyDir(rootDir);
+  const bumpyRelDir = relative(rootDir, bumpyDir);
+  const fileStatuses = getFileStatuses(bumpyRelDir, { cwd: rootDir });
+
+  // Augment changedFiles with untracked/staged bump files that aren't already in the list
+  const augmentedChangedFiles = [...changedFiles];
+  for (const [file] of fileStatuses) {
+    if (file.endsWith('.md') && !file.endsWith('README.md') && !augmentedChangedFiles.includes(file)) {
+      augmentedChangedFiles.push(file);
+    }
+  }
+
+  const { branchBumpFiles, emptyBumpFileIds } = filterBranchBumpFiles(allBumpFiles, augmentedChangedFiles, rootDir);
+
+  // Determine which bump files count based on hook context
+  const bumpFileStatuses = new Map<string, 'committed' | 'staged' | 'untracked'>();
+  for (const bf of branchBumpFiles) {
+    const filePath = `${bumpyRelDir}/${bf.id}.md`;
+    const status = fileStatuses.get(filePath);
+    bumpFileStatuses.set(bf.id, status ?? 'committed');
+  }
+  for (const id of emptyBumpFileIds) {
+    const filePath = `${bumpyRelDir}/${id}.md`;
+    const status = fileStatuses.get(filePath);
+    bumpFileStatuses.set(id, status ?? 'committed');
+  }
+
+  // Filter bump files based on hook context
+  const effectiveBumpFiles = opts.hook
+    ? branchBumpFiles.filter((bf) => {
+        const status = bumpFileStatuses.get(bf.id)!;
+        if (opts.hook === 'pre-push') return status === 'committed';
+        if (opts.hook === 'pre-commit') return status !== 'untracked';
+        return true;
+      })
+    : branchBumpFiles;
+
+  const effectiveEmptyIds = opts.hook
+    ? emptyBumpFileIds.filter((id) => {
+        const status = bumpFileStatuses.get(id)!;
+        if (opts.hook === 'pre-push') return status === 'committed';
+        if (opts.hook === 'pre-commit') return status !== 'untracked';
+        return true;
+      })
+    : emptyBumpFileIds;
+
+  // Warn about bump files that won't count in the current hook context
+  if (opts.hook) {
+    const excludedBumpFiles = branchBumpFiles.filter((bf) => !effectiveBumpFiles.includes(bf));
+    const excludedEmptyIds = emptyBumpFileIds.filter((id) => !effectiveEmptyIds.includes(id));
+
+    for (const bf of excludedBumpFiles) {
+      const status = bumpFileStatuses.get(bf.id)!;
+      if (opts.hook === 'pre-push' && status === 'staged') {
+        log.warn(`${bumpyRelDir}/${bf.id}.md is staged but not committed — it won't be included in the push`);
+      } else if (status === 'untracked') {
+        log.warn(`${bumpyRelDir}/${bf.id}.md is untracked — run \`git add\` to include it`);
+      }
+    }
+    for (const id of excludedEmptyIds) {
+      const status = bumpFileStatuses.get(id)!;
+      if (opts.hook === 'pre-push' && status === 'staged') {
+        log.warn(`${bumpyRelDir}/${id}.md is staged but not committed — it won't be included in the push`);
+      } else if (status === 'untracked') {
+        log.warn(`${bumpyRelDir}/${id}.md is untracked — run \`git add\` to include it`);
+      }
+    }
+  }
 
   // If an empty bump file exists on this branch, the check passes
-  if (emptyBumpFileIds.length > 0) {
+  if (effectiveEmptyIds.length > 0) {
     log.success('Empty bump file found — no releases needed.');
     return;
   }
 
   // Find which packages are covered by bump files on this branch
   const coveredPackages = new Set<string>();
-  for (const bf of branchBumpFiles) {
+  for (const bf of effectiveBumpFiles) {
     for (const release of bf.releases) {
       coveredPackages.add(release.name);
     }
@@ -67,7 +141,7 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
 
   // No bump files at all — fail by default
   const willFailNoBump = !opts.noFail;
-  if (branchBumpFiles.length === 0) {
+  if (effectiveBumpFiles.length === 0) {
     (willFailNoBump ? log.error : log.warn)(`${changedPackages.length} changed package(s) missing bump files:\n`);
     for (const name of changedPackages) {
       console.log(`  ${colorize(name, 'yellow')}`);
@@ -84,6 +158,11 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
 
   if (missing.length === 0) {
     log.success(`🐸 All ${changedPackages.length} changed package(s) have bump files.`);
+    printBumpFileList(
+      effectiveBumpFiles.map((bf) => bf.id),
+      bumpyRelDir,
+      bumpFileStatuses,
+    );
     return;
   }
 
@@ -94,24 +173,43 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     console.log(`  ${colorize(name, 'yellow')}`);
   }
 
-  if (branchBumpFiles.length > 0) {
+  if (effectiveBumpFiles.length > 0) {
     console.log();
-    log.dim(`Existing bump files on this branch:`);
-    for (const bf of branchBumpFiles) {
-      log.dim(`  ${getBumpyDir(rootDir)}/${bf.id}.md`);
-    }
+    printBumpFileList(
+      effectiveBumpFiles.map((bf) => bf.id),
+      bumpyRelDir,
+      bumpFileStatuses,
+    );
   }
 
   console.log();
   if (opts.strict) {
     log.dim(
-      "Run `bumpy add` to create a bump file. Use bump type `none` for packages that changed but don't need a release.",
+      "Run `bumpy add` to create a bump file. Use bump type `none` for packages that changed but don't need a bump.",
     );
   } else {
     log.dim('Run `bumpy add` to create a bump file, or `bumpy add --empty` if no release is needed.');
   }
   log.dim('To adjust which files trigger change detection, set `changedFilePatterns` in .bumpy/_config.json.');
   if (willFailUncovered) process.exit(1);
+}
+
+function printBumpFileList(
+  ids: string[],
+  bumpyRelDir: string,
+  statuses: Map<string, 'committed' | 'staged' | 'untracked'>,
+): void {
+  log.dim('Bump files on this branch:');
+  for (const id of ids) {
+    const status = statuses.get(id);
+    const statusLabel =
+      status === 'staged'
+        ? colorize(' (staged)', 'yellow')
+        : status === 'untracked'
+          ? colorize(' (untracked)', 'yellow')
+          : '';
+    log.dim(`  ${bumpyRelDir}/${id}.md${statusLabel}`);
+  }
 }
 
 /** Map changed files to the packages they belong to */

--- a/packages/bumpy/src/core/changelog.ts
+++ b/packages/bumpy/src/core/changelog.ts
@@ -27,7 +27,7 @@ export type ChangelogFormatter = (ctx: ChangelogContext) => string | Promise<str
 /** Get the bump type a bump file applies to a specific package */
 export function getBumpTypeForPackage(bf: BumpFile, packageName: string): BumpType {
   const rel = bf.releases.find((r) => r.name === packageName);
-  return rel?.type === 'none' ? 'patch' : (rel?.type ?? 'patch');
+  return rel?.type === 'none' || !rel?.type ? 'patch' : rel.type;
 }
 
 /** Sort bump files by bump type for a specific package (major → minor → patch) */

--- a/packages/bumpy/src/core/git.ts
+++ b/packages/bumpy/src/core/git.ts
@@ -91,6 +91,27 @@ export function getFilesChangedInCommit(hash: string, opts?: { cwd?: string }): 
   return result.split('\n').filter(Boolean);
 }
 
+/** Get the git status of files in a directory (staged, unstaged, untracked) */
+export function getFileStatuses(
+  dir: string,
+  opts?: { cwd?: string },
+): Map<string, 'committed' | 'staged' | 'untracked'> {
+  const statuses = new Map<string, 'committed' | 'staged' | 'untracked'>();
+  const result = tryRunArgs(['git', 'status', '--porcelain', '--', dir], opts);
+  if (!result) return statuses;
+  for (const line of result.split('\n')) {
+    if (!line.trim()) continue;
+    const indexStatus = line[0]!;
+    const file = line.slice(3);
+    if (indexStatus === '?') {
+      statuses.set(file, 'untracked');
+    } else {
+      statuses.set(file, 'staged');
+    }
+  }
+  return statuses;
+}
+
 /** Get all tags matching a pattern */
 export function listTags(pattern: string, opts?: { cwd?: string }): string[] {
   const result = tryRunArgs(['git', 'tag', '-l', pattern], opts);

--- a/packages/bumpy/src/core/release-plan.ts
+++ b/packages/bumpy/src/core/release-plan.ts
@@ -18,8 +18,6 @@ import {
 
 interface PlannedBump {
   type: BumpType;
-  /** Explicit 'none' from bump file — suppresses propagation bumps */
-  suppressed: boolean;
   isDependencyBump: boolean;
   isCascadeBump: boolean;
   bumpFiles: Set<string>;
@@ -49,17 +47,15 @@ export function assembleReleasePlan(
 
   // Step 1: Collect explicit bumps from bump files
   const cascadeOverrides = new Map<string, Map<string, BumpType>>(); // pkg → (glob → bumpType)
-  const suppressedPackages = new Set<string>(); // packages with explicit 'none'
 
   for (const bf of bumpFiles) {
     for (const release of bf.releases) {
       if (!packages.has(release.name)) continue;
       const bump = release.type;
 
-      if (bump === 'none') {
-        suppressedPackages.add(release.name);
-        continue;
-      }
+      // 'none' means "no direct bump needed" — just skip it.
+      // Cascading bumps from other packages can still add this package later.
+      if (bump === 'none') continue;
 
       const existing = planned.get(release.name);
       if (existing) {
@@ -68,7 +64,6 @@ export function assembleReleasePlan(
       } else {
         planned.set(release.name, {
           type: bump,
-          suppressed: false,
           isDependencyBump: false,
           isCascadeBump: false,
           bumpFiles: new Set([bf.id]),
@@ -89,21 +84,6 @@ export function assembleReleasePlan(
     }
   }
 
-  // Mark suppressed packages (explicit 'none' in bump file)
-  for (const name of suppressedPackages) {
-    if (!planned.has(name)) {
-      // Create a placeholder that will be removed later
-      // This prevents propagation from adding this package
-      planned.set(name, {
-        type: 'patch', // placeholder, won't be used
-        suppressed: true,
-        isDependencyBump: false,
-        isCascadeBump: false,
-        bumpFiles: new Set(),
-      });
-    }
-  }
-
   // Step 2: Propagation loop (iterative until stable)
   let changed = true;
   let iterations = 0;
@@ -115,8 +95,6 @@ export function assembleReleasePlan(
 
     // Phase A: Fix out-of-range dependencies (always runs)
     for (const [pkgName, bump] of planned) {
-      if (bump.suppressed) continue;
-
       const pkg = packages.get(pkgName)!;
       const newVersion = bumpVersion(pkg.version, bump.type);
       const dependents = depGraph.getDependents(pkgName);
@@ -137,16 +115,6 @@ export function assembleReleasePlan(
         } else {
           // dependencies / optionalDependencies get patch
           depBump = 'patch';
-        }
-
-        // Check if the dependent is suppressed
-        const existingDep = planned.get(dep.name);
-        if (existingDep?.suppressed) {
-          throw new Error(
-            `Cannot suppress bump for '${dep.name}' (via 'none' in bump file) — ` +
-              `'${pkgName}' is bumping to ${newVersion} which breaks the declared range '${dep.versionRange}'. ` +
-              `Either widen the range or remove the 'none' entry.`,
-          );
         }
 
         // Warn about ^0.x peer dep propagation
@@ -176,7 +144,6 @@ export function assembleReleasePlan(
       let groupBump: BumpType | undefined;
       for (const nameOrGlob of group) {
         for (const [name, bump] of planned) {
-          if (bump.suppressed) continue;
           if (matchGlob(name, nameOrGlob)) {
             groupBump = maxBump(groupBump, bump.type);
           }
@@ -187,7 +154,6 @@ export function assembleReleasePlan(
         for (const [name] of packages) {
           if (!matchGlob(name, nameOrGlob)) continue;
           const existing = planned.get(name);
-          if (existing && existing.suppressed) continue;
           if (existing) {
             const newType = maxBump(existing.type, groupBump);
             if (newType !== existing.type) {
@@ -197,7 +163,6 @@ export function assembleReleasePlan(
           } else {
             planned.set(name, {
               type: groupBump,
-              suppressed: false,
               isDependencyBump: false,
               isCascadeBump: false,
               bumpFiles: new Set(),
@@ -213,7 +178,6 @@ export function assembleReleasePlan(
       let groupBump: BumpType | undefined;
       for (const nameOrGlob of group) {
         for (const [name, bump] of planned) {
-          if (bump.suppressed) continue;
           if (matchGlob(name, nameOrGlob)) {
             groupBump = maxBump(groupBump, bump.type);
           }
@@ -224,7 +188,7 @@ export function assembleReleasePlan(
         for (const [name] of packages) {
           if (!matchGlob(name, nameOrGlob)) continue;
           const existing = planned.get(name);
-          if (!existing || existing.suppressed) continue;
+          if (!existing) continue;
           const newType = maxBump(existing.type, groupBump);
           if (newType !== existing.type) {
             existing.type = newType;
@@ -237,8 +201,6 @@ export function assembleReleasePlan(
     // Phase C: Proactive propagation (only when updateInternalDependencies !== 'out-of-range')
     if (config.updateInternalDependencies !== 'out-of-range') {
       for (const [pkgName, bump] of planned) {
-        if (bump.suppressed) continue;
-
         // Check minimum threshold for proactive propagation
         if (config.updateInternalDependencies === 'minor' && bumpLevel(bump.type) < bumpLevel('minor')) {
           continue;
@@ -250,8 +212,6 @@ export function assembleReleasePlan(
           for (const [pattern, cascadeBumpType] of bfOverrides) {
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              const existingTarget = planned.get(targetName);
-              if (existingTarget?.suppressed) continue;
               if (applyBump(planned, targetName, cascadeBumpType, false, true, bump.bumpFiles)) {
                 changed = true;
               }
@@ -268,8 +228,6 @@ export function assembleReleasePlan(
             const cascadeBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              const existingTarget = planned.get(targetName);
-              if (existingTarget?.suppressed) continue;
               if (applyBump(planned, targetName, cascadeBump, false, true, bump.bumpFiles)) {
                 changed = true;
               }
@@ -284,9 +242,6 @@ export function assembleReleasePlan(
           if (!rule) continue; // disabled for this dep type
           if (!shouldTrigger(bump.type, rule.trigger)) continue;
 
-          const existingDep = planned.get(dep.name);
-          if (existingDep?.suppressed) continue;
-
           const depBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
           if (applyBump(planned, dep.name, depBump, true, false, bump.bumpFiles)) {
             changed = true;
@@ -296,16 +251,12 @@ export function assembleReleasePlan(
     } else {
       // Even in out-of-range mode, still apply bump file cascades and cascadeTo
       for (const [pkgName, bump] of planned) {
-        if (bump.suppressed) continue;
-
         // Bump-file-level cascade overrides always apply
         const bfOverrides = cascadeOverrides.get(pkgName);
         if (bfOverrides) {
           for (const [pattern, cascadeBumpType] of bfOverrides) {
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              const existingTarget = planned.get(targetName);
-              if (existingTarget?.suppressed) continue;
               if (applyBump(planned, targetName, cascadeBumpType, false, true, bump.bumpFiles)) {
                 changed = true;
               }
@@ -322,8 +273,6 @@ export function assembleReleasePlan(
             const cascadeBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              const existingTarget = planned.get(targetName);
-              if (existingTarget?.suppressed) continue;
               if (applyBump(planned, targetName, cascadeBump, false, true, bump.bumpFiles)) {
                 changed = true;
               }
@@ -334,36 +283,9 @@ export function assembleReleasePlan(
     }
   }
 
-  // Step 3: Validate suppressed packages — check that their ranges are still satisfied
-  for (const [name, bump] of planned) {
-    if (!bump.suppressed) continue;
-    // Check all dependencies of this package to ensure none are broken
-    const pkg = packages.get(name)!;
-    // Check if any planned bump on a dependency would break this package's range
-    for (const [depName, depBump] of planned) {
-      if (depBump.suppressed) continue;
-      const depPkg = packages.get(depName)!;
-      const newDepVersion = bumpVersion(depPkg.version, depBump.type);
-
-      // Check all dep types
-      for (const depType of ['dependencies', 'peerDependencies', 'optionalDependencies'] as const) {
-        const range = pkg[depType]?.[depName];
-        if (!range) continue;
-        if (!satisfies(newDepVersion, range, depPkg.version)) {
-          throw new Error(
-            `Cannot suppress bump for '${name}' (via 'none' in bump file) — ` +
-              `'${depName}' is bumping to ${newDepVersion} which breaks the declared range '${range}'. ` +
-              `Either widen the range or remove the 'none' entry.`,
-          );
-        }
-      }
-    }
-  }
-
-  // Step 4: Calculate new versions (exclude suppressed)
+  // Step 3: Calculate new versions
   const releases: PlannedRelease[] = [];
   for (const [name, bump] of planned) {
-    if (bump.suppressed) continue;
     const pkg = packages.get(name);
     if (!pkg) continue;
 
@@ -408,7 +330,6 @@ function applyBump(
 ): boolean {
   const existing = planned.get(name);
   if (existing) {
-    if (existing.suppressed) return false;
     const newType = maxBump(existing.type, type);
     if (newType === existing.type) return false;
     existing.type = newType;
@@ -419,7 +340,6 @@ function applyBump(
   }
   planned.set(name, {
     type,
-    suppressed: false,
     isDependencyBump,
     isCascadeBump,
     bumpFiles: new Set(sourceBumpFiles),

--- a/packages/bumpy/test/core/bump-file.test.ts
+++ b/packages/bumpy/test/core/bump-file.test.ts
@@ -28,7 +28,7 @@ Added a new feature to pkg-a
 "pkg-b": none
 ---
 
-Feature in pkg-a, suppress bump on pkg-b
+Feature in pkg-a, no bump needed for pkg-b
 `;
     const { bumpFile: bf, errors } = parseBumpFile(content, 'test-bf');
     expect(errors).toHaveLength(0);

--- a/packages/bumpy/test/core/release-plan.test.ts
+++ b/packages/bumpy/test/core/release-plan.test.ts
@@ -408,8 +408,8 @@ describe('assembleReleasePlan', () => {
 
   // ---- none behavior ----
 
-  describe('none suppression', () => {
-    test('none suppresses bump when range is satisfied', () => {
+  describe('none bump type', () => {
+    test('none skips direct bump but allows cascade bumps', () => {
       const packages = new Map([
         ['core', makePkg('core', '1.0.0')],
         ['plugin', makePkg('plugin', '1.0.0', { dependencies: { core: '^1.0.0' } })],
@@ -429,12 +429,40 @@ describe('assembleReleasePlan', () => {
       const graph = new DependencyGraph(packages);
       const plan = assembleReleasePlan(bumpFiles, packages, graph, makeConfig({ updateInternalDependencies: 'patch' }));
 
-      // Plugin should NOT be in releases because it's suppressed
+      // Plugin SHOULD be in releases — none doesn't suppress cascading bumps
+      expect(plan.releases).toHaveLength(2);
+      expect(plan.releases.find((r) => r.name === 'core')!.type).toBe('minor');
+      const pluginRelease = plan.releases.find((r) => r.name === 'plugin')!;
+      expect(pluginRelease.type).toBe('patch');
+      expect(pluginRelease.isDependencyBump).toBe(true);
+    });
+
+    test('none skips direct bump when no cascade applies', () => {
+      const packages = new Map([
+        ['core', makePkg('core', '1.0.0')],
+        ['plugin', makePkg('plugin', '1.0.0', { dependencies: { core: '^1.0.0' } })],
+      ]);
+
+      const bumpFiles: BumpFile[] = [
+        {
+          id: 'cs1',
+          releases: [
+            { name: 'core', type: 'patch' },
+            { name: 'plugin', type: 'none' },
+          ],
+          summary: 'Fix',
+        },
+      ];
+
+      const graph = new DependencyGraph(packages);
+      // out-of-range mode: patch on core doesn't break ^1.0.0, so no cascade
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, makeConfig());
+
       expect(plan.releases).toHaveLength(1);
       expect(plan.releases[0]!.name).toBe('core');
     });
 
-    test('none that would break range throws error', () => {
+    test('none does not block out-of-range cascade', () => {
       const packages = new Map([
         ['core', makePkg('core', '1.0.0')],
         ['plugin', makePkg('plugin', '1.0.0', { dependencies: { core: '^1.0.0' } })],
@@ -452,9 +480,11 @@ describe('assembleReleasePlan', () => {
       ];
 
       const graph = new DependencyGraph(packages);
-      expect(() => assembleReleasePlan(bumpFiles, packages, graph, makeConfig())).toThrow(
-        /Cannot suppress.*plugin.*none/,
-      );
+      // core bumps to 2.0.0, breaking ^1.0.0 — plugin gets cascade bump
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, makeConfig());
+
+      expect(plan.releases).toHaveLength(2);
+      expect(plan.releases.find((r) => r.name === 'plugin')!.type).toBe('patch');
     });
   });
 
@@ -720,7 +750,7 @@ describe('assembleReleasePlan', () => {
   // ---- none edge cases ----
 
   describe('none edge cases', () => {
-    test('none on a package not otherwise in the plan is a no-op', () => {
+    test('none on an unrelated package is a no-op', () => {
       const packages = new Map([
         ['core', makePkg('core', '1.0.0')],
         ['unrelated', makePkg('unrelated', '1.0.0')],

--- a/packages/bumpy/test/helpers.ts
+++ b/packages/bumpy/test/helpers.ts
@@ -6,7 +6,15 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import type { WorkspacePackage, PlannedRelease, BumpType, BumpyConfig, BumpFile, ReleasePlan } from '../src/types.ts';
+import type {
+  WorkspacePackage,
+  PlannedRelease,
+  BumpType,
+  BumpTypeWithNone,
+  BumpyConfig,
+  BumpFile,
+  ReleasePlan,
+} from '../src/types.ts';
 import { DEFAULT_CONFIG } from '../src/types.ts';
 
 // ---- Factory functions ----
@@ -62,7 +70,7 @@ export function makeRelease(
 /** Create a BumpFile for testing */
 export function makeBumpFile(
   id: string,
-  releases: { name: string; type: BumpType }[],
+  releases: { name: string; type: BumpTypeWithNone }[],
   summary = 'Test change',
 ): BumpFile {
   return { id, releases, summary };


### PR DESCRIPTION
## Summary

- **`none` bump type no longer suppresses cascading bumps** — it now just skips the direct bump, while allowing dependency propagation to still apply normally. This makes `none` useful for acknowledging internal changes (tests, config) that don't need a release on their own, without blocking cascades.
- **`bumpy check` now detects untracked/staged bump files** — fixes the chicken-and-egg problem where bump files created but not yet committed weren't detected.
- **New `--hook pre-commit` / `--hook pre-push` flag** — controls which bump files count based on git status. Output annotates bump files with their status (staged, untracked).

## Test plan

- [x] All 202 existing tests pass
- [x] New tests cover `none` allowing cascades, `none` with no cascade, and `none` with out-of-range cascade
- [ ] Manual test: create bump file with `none`, verify `bumpy check` passes
- [ ] Manual test: verify `--hook pre-push` warns about uncommitted bump files