### PR TITLE
Fix CI check for unmanaged packages and none coverage

### DIFF
--- a/.bumpy/fix-ci-check.md
+++ b/.bumpy/fix-ci-check.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fixed CI check to skip gracefully when no managed packages changed, and count none entries as covered in strict mode.

--- a/packages/bumpy/src/commands/ci.ts
+++ b/packages/bumpy/src/commands/ci.ts
@@ -129,6 +129,13 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
       return;
     }
 
+    // Check if any managed packages actually changed — if not, no bump file is needed
+    const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
+    if (changedPackages.length === 0 && parseErrors.length === 0) {
+      log.info('No managed packages have changed — no bump files needed.');
+      return;
+    }
+
     const willFail = !opts.noFail || parseErrors.length > 0;
     const msg =
       parseErrors.length > 0
@@ -188,7 +195,13 @@ export async function ciCheckCommand(rootDir: string, opts: CheckOptions): Promi
   }
 
   // Check for uncovered packages
+  // Include both released packages and those explicitly listed in bump files (e.g. with 'none')
   const coveredPackages = new Set(plan.releases.map((r) => r.name));
+  for (const bf of prBumpFiles) {
+    for (const release of bf.releases) {
+      coveredPackages.add(release.name);
+    }
+  }
   const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
   const missing = changedPackages.filter((name) => !coveredPackages.has(name));
   if (missing.length > 0) {


### PR DESCRIPTION
## Summary

- **`bumpy ci check` no longer fails when only unmanaged packages changed** — exits cleanly with "No managed packages have changed" instead of erroring with "No bump files found"
- **`none` entries count as covered in CI strict mode** — previously only `plan.releases` was checked, so packages marked with `none` in bump files would incorrectly show as uncovered

## Test plan

- [x] All 202 tests pass
- [ ] Test in CI with a PR that only changes unmanaged files