### PR TITLE
Fix broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Tools like semantic-release infer version bumps from commit messages (`feat:` â†
 
 ## Why not just use changesets?
 
-Bumpy is built as a successor to [@changesets/changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated - hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [differences from changesets](https://github.com/dmno-dev/bumpy/blob/main/docs/differences-from-changesets.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
+Bumpy is built as a successor to [changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated - hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [differences from changesets](https://github.com/dmno-dev/bumpy/blob/main/docs/differences-from-changesets.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
 
 - **Sane dependency propagation** - changesets hardcodes aggressive behavior where a minor bump triggers a major bump on all peer dependents. Bumpy uses a [three-phase algorithm](https://github.com/dmno-dev/bumpy/blob/main/docs/version-propagation.md) with sensible defaults and full configurability.
 - **Workspace protocol resolution** - changesets uses `npm publish` even in pnpm/yarn workspaces, so `workspace:^` and `catalog:` protocols are NOT resolved, resulting in broken published packages.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Tools like semantic-release infer version bumps from commit messages (`feat:` â†
 
 ## Why not just use changesets?
 
-Bumpy is built as a successor to [changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated - hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [differences from changesets](https://github.com/dmno-dev/bumpy/blob/main/docs/differences-from-changesets.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
+Bumpy is built as a successor to [ðŸ¦‹changesets](https://github.com/changesets/changesets). Changesets is mature and widely adopted, but has stagnated - hundreds of open issues around core design problems that are unlikely to be fixed without a rewrite. See [differences from changesets](https://github.com/dmno-dev/bumpy/blob/main/docs/differences-from-changesets.md) for a detailed comparison with links to specific issues. The biggest pain points bumpy addresses:
 
 - **Sane dependency propagation** - changesets hardcodes aggressive behavior where a minor bump triggers a major bump on all peer dependents. Bumpy uses a [three-phase algorithm](https://github.com/dmno-dev/bumpy/blob/main/docs/version-propagation.md) with sensible defaults and full configurability.
 - **Workspace protocol resolution** - changesets uses `npm publish` even in pnpm/yarn workspaces, so `workspace:^` and `catalog:` protocols are NOT resolved, resulting in broken published packages.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,11 +65,16 @@ Consume all pending bump files and apply the release plan:
 3. Generates CHANGELOG.md entries
 4. Deletes consumed bump files
 5. Updates the lockfile
-6. Optionally commits (if `commit: true` in config)
+6. Optionally commits (with `--commit` flag)
 
 ```bash
 bumpy version
+bumpy version --commit
 ```
+
+| Flag       | Description                       |
+| ---------- | --------------------------------- |
+| `--commit` | Commit the version changes to git |
 
 ## `bumpy publish`
 

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -1,6 +1,6 @@
 # Differences from Changesets
 
-Bumpy is built as a modern successor to [@changesets/changesets](https://github.com/changesets/changesets). This document tracks the pain points, missing features, and design problems in changesets that bumpy addresses (or plans to address), with links back to the relevant GitHub issues.
+Bumpy is built as a modern successor to [changesets](https://github.com/changesets/changesets). This document tracks the pain points, missing features, and design problems in changesets that bumpy addresses (or plans to address), with links back to the relevant GitHub issues.
 
 ---
 

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -21,7 +21,7 @@ Key differences from changesets:
 - Out-of-range peer dep bumps match the triggering bump level (not always major) — a minor bump on `core` → minor bump on `plugin`, not major
 - Dev deps never propagate by default (configurable per-package for bundled devDeps)
 - `cascadeTo` config for source-side "when I change, cascade to these packages"
-- Per-bump-file `none` to suppress propagation on specific changes
+- Per-bump-file `none` to acknowledge changes without triggering a direct bump
 - Warns about `^0.x` caret range gotchas and `workspace:*` on peer deps
 
 See [docs/version-propagation.md](./version-propagation.md) for the full algorithm.

--- a/docs/differences-from-changesets.md
+++ b/docs/differences-from-changesets.md
@@ -24,7 +24,7 @@ Key differences from changesets:
 - Per-bump-file `none` to suppress propagation on specific changes
 - Warns about `^0.x` caret range gotchas and `workspace:*` on peer deps
 
-See [docs/version-propagation.md](docs/version-propagation.md) for the full algorithm.
+See [docs/version-propagation.md](./version-propagation.md) for the full algorithm.
 
 - [changesets#1011](https://github.com/changesets/changesets/issues/1011) — peerDependencies cause unnecessary major bumps (70+ thumbs-up)
 - [changesets#822](https://github.com/changesets/changesets/issues/822) — unexpected major version bumps from peer deps


### PR DESCRIPTION
## Summary
- Fixed broken relative link in `differences-from-changesets.md` — `docs/version-propagation.md` → `./version-propagation.md`