### PR TITLE
Skip ^0.x peer dep warning on major bump cascade

### DIFF
--- a/.bumpy/skip-0x-warning-major.md
+++ b/.bumpy/skip-0x-warning-major.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Skip ^0.x peer dep warning when major bump triggers major cascade

--- a/packages/bumpy/src/core/release-plan.ts
+++ b/packages/bumpy/src/core/release-plan.ts
@@ -117,8 +117,8 @@ export function assembleReleasePlan(
           depBump = 'patch';
         }
 
-        // Warn about ^0.x peer dep propagation
-        if (dep.depType === 'peerDependencies' && depBump !== 'patch') {
+        // Warn about ^0.x peer dep propagation (only when it's surprising, not for major→major)
+        if (dep.depType === 'peerDependencies' && depBump !== 'patch' && bump.type !== 'major') {
           // Resolve workspace:^ to ^<version> for checking
           let resolvedRange = dep.versionRange.replace(/^workspace:/, '');
           if (resolvedRange === '^' || resolvedRange === '~') {


### PR DESCRIPTION
## Summary
- The `^0.x` peer dep warning is only useful when a minor bump causes surprising propagation due to npm's caret semantics on pre-1.0 packages
- When a major bump naturally cascades as major, there's nothing unexpected — skip the warning in that case