### PR TITLE
Show source package info in changelogs for indirect bumps

### DIFF
--- a/.bumpy/changelog-bump-sources.md
+++ b/.bumpy/changelog-bump-sources.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Show source package info in changelogs for indirect bumps instead of inheriting the source package's change descriptions

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,5 +11,8 @@ pre-commit:
 
 pre-push:
   jobs:
+    - name: typecheck
+      run: bunx tsc --noEmit
+      root: packages/bumpy/
     - name: bumpy-check
       run: bunx @varlock/bumpy check --hook pre-push

--- a/packages/bumpy/src/commands/publish.ts
+++ b/packages/bumpy/src/commands/publish.ts
@@ -157,6 +157,8 @@ async function findUnpublishedPackages(
         bumpFiles: [],
         isDependencyBump: false,
         isCascadeBump: false,
+        isGroupBump: false,
+        bumpSources: [],
       });
     }
   }

--- a/packages/bumpy/src/core/changelog-github.ts
+++ b/packages/bumpy/src/core/changelog-github.ts
@@ -96,13 +96,20 @@ export function createGithubFormatter(options: GithubChangelogOptions = {}): Cha
       }
     }
 
+    const sourceList =
+      release.bumpSources.length > 0 ? release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ') : '';
+
     if (release.isDependencyBump) {
       const depTag = release.type !== 'patch' ? ` *(patch)* -` : '';
-      lines.push(`-${depTag} Updated dependencies`);
+      lines.push(`-${depTag} Updated dependency ${sourceList || '(internal)'}`);
     }
 
-    if (release.isCascadeBump && !release.isDependencyBump && relevantBumpFiles.length === 0) {
-      lines.push('- Version bump via cascade rule');
+    if (release.isGroupBump) {
+      lines.push(sourceList ? `- Version bump from group with ${sourceList}` : '- Version bump from group');
+    }
+
+    if (release.isCascadeBump && !release.isDependencyBump && !release.isGroupBump) {
+      lines.push(sourceList ? `- Version bump from ${sourceList}` : '- Version bump via cascade rule');
     }
 
     lines.push('');

--- a/packages/bumpy/src/core/changelog.ts
+++ b/packages/bumpy/src/core/changelog.ts
@@ -65,13 +65,20 @@ export const defaultFormatter: ChangelogFormatter = (ctx) => {
     }
   }
 
+  const sourceList =
+    release.bumpSources.length > 0 ? release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ') : '';
+
   if (release.isDependencyBump) {
     const tag = release.type !== 'patch' ? `*(patch)* ` : '';
-    lines.push(`- ${tag}Updated dependencies`);
+    lines.push(`- ${tag}Updated dependency ${sourceList || '(internal)'}`);
   }
 
-  if (release.isCascadeBump && !release.isDependencyBump && relevantBumpFiles.length === 0) {
-    lines.push('- Version bump via cascade rule');
+  if (release.isGroupBump) {
+    lines.push(sourceList ? `- Version bump from group with ${sourceList}` : '- Version bump from group');
+  }
+
+  if (release.isCascadeBump && !release.isDependencyBump && !release.isGroupBump) {
+    lines.push(sourceList ? `- Version bump from ${sourceList}` : '- Version bump via cascade rule');
   }
 
   lines.push('');

--- a/packages/bumpy/src/core/github-release.ts
+++ b/packages/bumpy/src/core/github-release.ts
@@ -137,9 +137,14 @@ async function generateAggregateBody(
       if (body) {
         lines.push(body);
       } else if (release.isDependencyBump) {
-        lines.push('- Updated dependencies');
+        const sourceList = release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ');
+        lines.push(sourceList ? `- Updated dependency ${sourceList}` : '- Updated dependencies');
+      } else if (release.isGroupBump) {
+        const sourceList = release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ');
+        lines.push(sourceList ? `- Version bump from group with ${sourceList}` : '- Version bump from group');
       } else if (release.isCascadeBump) {
-        lines.push('- Version bump via cascade rule');
+        const sourceList = release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ');
+        lines.push(sourceList ? `- Version bump from ${sourceList}` : '- Version bump via cascade rule');
       }
       lines.push('');
     }
@@ -168,8 +173,15 @@ function buildReleaseBody(release: PlannedRelease, bumpFiles: BumpFile[]): strin
     }
   }
 
-  if (release.isDependencyBump && relevant.length === 0) {
-    lines.push('- Updated dependencies');
+  if (relevant.length === 0) {
+    const sourceList = release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ');
+    if (release.isDependencyBump) {
+      lines.push(sourceList ? `- Updated dependency ${sourceList}` : '- Updated dependencies');
+    } else if (release.isGroupBump) {
+      lines.push(sourceList ? `- Version bump from group with ${sourceList}` : '- Version bump from group');
+    } else if (release.isCascadeBump) {
+      lines.push(sourceList ? `- Version bump from ${sourceList}` : '- Version bump via cascade rule');
+    }
   }
 
   return lines.join('\n') || 'No changelog entries.';
@@ -198,10 +210,15 @@ function buildAggregateBody(releases: PlannedRelease[], bumpFiles: BumpFile[]): 
             lines.push(`- ${bf.summary.split('\n')[0]}`);
           }
         }
-      } else if (release.isDependencyBump) {
-        lines.push('- Updated dependencies');
-      } else if (release.isCascadeBump) {
-        lines.push('- Version bump via cascade rule');
+      } else {
+        const sourceList = release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ');
+        if (release.isDependencyBump) {
+          lines.push(sourceList ? `- Updated dependency ${sourceList}` : '- Updated dependencies');
+        } else if (release.isGroupBump) {
+          lines.push(sourceList ? `- Version bump from group with ${sourceList}` : '- Version bump from group');
+        } else if (release.isCascadeBump) {
+          lines.push(sourceList ? `- Version bump from ${sourceList}` : '- Version bump via cascade rule');
+        }
       }
       lines.push('');
     }

--- a/packages/bumpy/src/core/release-plan.ts
+++ b/packages/bumpy/src/core/release-plan.ts
@@ -20,7 +20,10 @@ interface PlannedBump {
   type: BumpType;
   isDependencyBump: boolean;
   isCascadeBump: boolean;
+  isGroupBump: boolean;
   bumpFiles: Set<string>;
+  /** Package names that caused this bump via dependency/cascade/group propagation */
+  bumpSources: Set<string>;
 }
 
 /**
@@ -66,7 +69,9 @@ export function assembleReleasePlan(
           type: bump,
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
           bumpFiles: new Set([bf.id]),
+          bumpSources: new Set(),
         });
       }
 
@@ -133,7 +138,7 @@ export function assembleReleasePlan(
           }
         }
 
-        if (applyBump(planned, dep.name, depBump, true, false, bump.bumpFiles)) {
+        if (applyBump(planned, dep.name, depBump, true, false, pkgName)) {
           changed = true;
         }
       }
@@ -142,10 +147,17 @@ export function assembleReleasePlan(
     // Phase B: Enforce fixed/linked group constraints
     for (const group of config.fixed) {
       let groupBump: BumpType | undefined;
+      const groupSources: string[] = [];
       for (const nameOrGlob of group) {
         for (const [name, bump] of planned) {
           if (matchGlob(name, nameOrGlob)) {
-            groupBump = maxBump(groupBump, bump.type);
+            if (!groupBump || bumpLevel(bump.type) > bumpLevel(groupBump)) {
+              groupBump = bump.type;
+              groupSources.length = 0;
+              groupSources.push(name);
+            } else if (bump.type === groupBump) {
+              groupSources.push(name);
+            }
           }
         }
       }
@@ -158,6 +170,10 @@ export function assembleReleasePlan(
             const newType = maxBump(existing.type, groupBump);
             if (newType !== existing.type) {
               existing.type = newType;
+              existing.isGroupBump = true;
+              for (const src of groupSources) {
+                if (src !== name) existing.bumpSources.add(src);
+              }
               changed = true;
             }
           } else {
@@ -165,7 +181,9 @@ export function assembleReleasePlan(
               type: groupBump,
               isDependencyBump: false,
               isCascadeBump: false,
+              isGroupBump: true,
               bumpFiles: new Set(),
+              bumpSources: new Set(groupSources.filter((s) => s !== name)),
             });
             changed = true;
           }
@@ -176,10 +194,17 @@ export function assembleReleasePlan(
     // Linked groups (same bump level, independent versions, only already-planned packages)
     for (const group of config.linked) {
       let groupBump: BumpType | undefined;
+      const groupSources: string[] = [];
       for (const nameOrGlob of group) {
         for (const [name, bump] of planned) {
           if (matchGlob(name, nameOrGlob)) {
-            groupBump = maxBump(groupBump, bump.type);
+            if (!groupBump || bumpLevel(bump.type) > bumpLevel(groupBump)) {
+              groupBump = bump.type;
+              groupSources.length = 0;
+              groupSources.push(name);
+            } else if (bump.type === groupBump) {
+              groupSources.push(name);
+            }
           }
         }
       }
@@ -192,6 +217,10 @@ export function assembleReleasePlan(
           const newType = maxBump(existing.type, groupBump);
           if (newType !== existing.type) {
             existing.type = newType;
+            existing.isGroupBump = true;
+            for (const src of groupSources) {
+              if (src !== name) existing.bumpSources.add(src);
+            }
             changed = true;
           }
         }
@@ -212,7 +241,7 @@ export function assembleReleasePlan(
           for (const [pattern, cascadeBumpType] of bfOverrides) {
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              if (applyBump(planned, targetName, cascadeBumpType, false, true, bump.bumpFiles)) {
+              if (applyBump(planned, targetName, cascadeBumpType, false, true, pkgName)) {
                 changed = true;
               }
             }
@@ -228,7 +257,7 @@ export function assembleReleasePlan(
             const cascadeBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              if (applyBump(planned, targetName, cascadeBump, false, true, bump.bumpFiles)) {
+              if (applyBump(planned, targetName, cascadeBump, false, true, pkgName)) {
                 changed = true;
               }
             }
@@ -243,7 +272,7 @@ export function assembleReleasePlan(
           if (!shouldTrigger(bump.type, rule.trigger)) continue;
 
           const depBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
-          if (applyBump(planned, dep.name, depBump, true, false, bump.bumpFiles)) {
+          if (applyBump(planned, dep.name, depBump, true, false, pkgName)) {
             changed = true;
           }
         }
@@ -257,7 +286,7 @@ export function assembleReleasePlan(
           for (const [pattern, cascadeBumpType] of bfOverrides) {
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              if (applyBump(planned, targetName, cascadeBumpType, false, true, bump.bumpFiles)) {
+              if (applyBump(planned, targetName, cascadeBumpType, false, true, pkgName)) {
                 changed = true;
               }
             }
@@ -273,7 +302,7 @@ export function assembleReleasePlan(
             const cascadeBump = rule.bumpAs === 'match' ? bump.type : rule.bumpAs;
             for (const [targetName] of packages) {
               if (!matchGlob(targetName, pattern)) continue;
-              if (applyBump(planned, targetName, cascadeBump, false, true, bump.bumpFiles)) {
+              if (applyBump(planned, targetName, cascadeBump, false, true, pkgName)) {
                 changed = true;
               }
             }
@@ -298,6 +327,15 @@ export function assembleReleasePlan(
       bumpFiles: [...bump.bumpFiles],
       isDependencyBump: bump.isDependencyBump,
       isCascadeBump: bump.isCascadeBump,
+      isGroupBump: bump.isGroupBump,
+      bumpSources: [...bump.bumpSources].map((srcName) => {
+        const srcBump = planned.get(srcName);
+        const srcPkg = packages.get(srcName);
+        return {
+          name: srcName,
+          newVersion: srcPkg && srcBump ? bumpVersion(srcPkg.version, srcBump.type) : 'unknown',
+        };
+      }),
     });
   }
 
@@ -326,7 +364,7 @@ function applyBump(
   type: BumpType,
   isDependencyBump: boolean,
   isCascadeBump: boolean,
-  sourceBumpFiles: Set<string>,
+  sourcePackageName: string,
 ): boolean {
   const existing = planned.get(name);
   if (existing) {
@@ -335,14 +373,16 @@ function applyBump(
     existing.type = newType;
     if (isDependencyBump) existing.isDependencyBump = true;
     if (isCascadeBump) existing.isCascadeBump = true;
-    for (const bf of sourceBumpFiles) existing.bumpFiles.add(bf);
+    existing.bumpSources.add(sourcePackageName);
     return true;
   }
   planned.set(name, {
     type,
     isDependencyBump,
     isCascadeBump,
-    bumpFiles: new Set(sourceBumpFiles),
+    isGroupBump: false,
+    bumpFiles: new Set(),
+    bumpSources: new Set([sourcePackageName]),
   });
   return true;
 }

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -223,9 +223,12 @@ export interface PlannedRelease {
   type: BumpType;
   oldVersion: string;
   newVersion: string;
-  bumpFiles: string[]; // bump file IDs that contributed
+  bumpFiles: string[]; // bump file IDs that contributed (direct only)
   isDependencyBump: boolean;
   isCascadeBump: boolean;
+  isGroupBump: boolean;
+  /** Packages whose bumps caused this dependency/cascade/group bump, with their new versions */
+  bumpSources: Array<{ name: string; newVersion: string }>;
 }
 
 export interface ReleasePlan {

--- a/packages/bumpy/test/core/changelog-github.test.ts
+++ b/packages/bumpy/test/core/changelog-github.test.ts
@@ -135,7 +135,20 @@ describe('createGithubFormatter', () => {
     expect(result).not.toContain('issues/123');
   });
 
-  test('handles dependency bump with no bump files', async () => {
+  test('handles dependency bump with source packages', async () => {
+    const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
+    const release = makeRelease('pkg-a', '1.0.1', {
+      isDependencyBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '2.0.0' }],
+    });
+
+    const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('Updated dependency `core` v2.0.0');
+  });
+
+  test('handles dependency bump without source packages (fallback)', async () => {
     const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
     const release = makeRelease('pkg-a', '1.0.1', {
       isDependencyBump: true,
@@ -144,10 +157,23 @@ describe('createGithubFormatter', () => {
 
     const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
 
-    expect(result).toContain('- Updated dependencies');
+    expect(result).toContain('Updated dependency (internal)');
   });
 
-  test('handles cascade bump with no bump files', async () => {
+  test('handles cascade bump with source packages', async () => {
+    const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
+    const release = makeRelease('pkg-a', '1.0.1', {
+      isCascadeBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '1.1.0' }],
+    });
+
+    const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Version bump from `core` v1.1.0');
+  });
+
+  test('handles cascade bump without source packages (fallback)', async () => {
     const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
     const release = makeRelease('pkg-a', '1.0.1', {
       isCascadeBump: true,
@@ -157,6 +183,33 @@ describe('createGithubFormatter', () => {
     const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
 
     expect(result).toContain('- Version bump via cascade rule');
+  });
+
+  test('handles group bump with source packages', async () => {
+    const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
+    const release = makeRelease('types', '1.1.0', {
+      type: 'minor',
+      isGroupBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '1.1.0' }],
+    });
+
+    const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Version bump from group with `core` v1.1.0');
+  });
+
+  test('handles group bump without source packages (fallback)', async () => {
+    const formatter = createGithubFormatter({ repo: 'dmno-dev/bumpy' });
+    const release = makeRelease('types', '1.1.0', {
+      type: 'minor',
+      isGroupBump: true,
+      bumpFiles: [],
+    });
+
+    const result = await formatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Version bump from group');
   });
 
   test('resolves bump file info from git log', async () => {

--- a/packages/bumpy/test/core/changelog.test.ts
+++ b/packages/bumpy/test/core/changelog.test.ts
@@ -30,7 +30,19 @@ describe('defaultFormatter', () => {
     expect(result.indexOf('Added new feature')).toBeLessThan(result.indexOf('Fixed a bug'));
   });
 
-  test('formats dependency bump with no bump files', async () => {
+  test('formats dependency bump with source packages', async () => {
+    const release = makeRelease('pkg-a', '1.0.1', {
+      isDependencyBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '2.0.0' }],
+    });
+
+    const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Updated dependency `core` v2.0.0');
+  });
+
+  test('formats dependency bump without source packages (fallback)', async () => {
     const release = makeRelease('pkg-a', '1.0.1', {
       isDependencyBump: true,
       bumpFiles: [],
@@ -38,10 +50,22 @@ describe('defaultFormatter', () => {
 
     const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
 
-    expect(result).toContain('- Updated dependencies');
+    expect(result).toContain('- Updated dependency (internal)');
   });
 
-  test('formats cascade bump with no bump files', async () => {
+  test('formats cascade bump with source packages', async () => {
+    const release = makeRelease('pkg-a', '1.0.1', {
+      isCascadeBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '1.1.0' }],
+    });
+
+    const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Version bump from `core` v1.1.0');
+  });
+
+  test('formats cascade bump without source packages (fallback)', async () => {
     const release = makeRelease('pkg-a', '1.0.1', {
       isCascadeBump: true,
       bumpFiles: [],
@@ -52,17 +76,76 @@ describe('defaultFormatter', () => {
     expect(result).toContain('- Version bump via cascade rule');
   });
 
-  test('dependency bump takes precedence over cascade in message', async () => {
-    const release = makeRelease('pkg-a', '1.0.1', {
-      isDependencyBump: true,
-      isCascadeBump: true,
+  test('formats group bump with source packages', async () => {
+    const release = makeRelease('types', '1.1.0', {
+      type: 'minor',
+      isGroupBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '1.1.0' }],
+    });
+
+    const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Version bump from group with `core` v1.1.0');
+  });
+
+  test('formats group bump without source packages (fallback)', async () => {
+    const release = makeRelease('types', '1.1.0', {
+      type: 'minor',
+      isGroupBump: true,
       bumpFiles: [],
     });
 
     const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
 
-    expect(result).toContain('- Updated dependencies');
+    expect(result).toContain('- Version bump from group');
+  });
+
+  test('dependency + cascade shows only dependency message', async () => {
+    const release = makeRelease('pkg-a', '1.0.1', {
+      isDependencyBump: true,
+      isCascadeBump: true,
+      bumpFiles: [],
+      bumpSources: [{ name: 'core', newVersion: '2.0.0' }],
+    });
+
+    const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('- Updated dependency `core` v2.0.0');
     expect(result).not.toContain('cascade');
+  });
+
+  test('dependency + group shows both messages', async () => {
+    const release = makeRelease('plugin-b', '1.1.0', {
+      type: 'minor',
+      isDependencyBump: true,
+      isGroupBump: true,
+      bumpFiles: [],
+      bumpSources: [
+        { name: 'core', newVersion: '2.0.0' },
+        { name: 'plugin-a', newVersion: '1.1.0' },
+      ],
+    });
+
+    const result = await defaultFormatter({ release, bumpFiles: [], date: '2026-04-14' });
+
+    expect(result).toContain('Updated dependency');
+    expect(result).toContain('Version bump from group with');
+  });
+
+  test('direct changes + group upgrade shows both', async () => {
+    const release = makeRelease('pkg-b', '1.1.0', {
+      type: 'minor',
+      isGroupBump: true,
+      bumpFiles: ['cs1'],
+      bumpSources: [{ name: 'pkg-a', newVersion: '1.1.0' }],
+    });
+    const bumpFiles = [makeBumpFile('cs1', [{ name: 'pkg-b', type: 'patch' }], 'Fixed a typo')];
+
+    const result = await defaultFormatter({ release, bumpFiles, date: '2026-04-14' });
+
+    expect(result).toContain('*(patch)* Fixed a typo');
+    expect(result).toContain('Version bump from group with `pkg-a` v1.1.0');
   });
 
   test('handles multi-line bump file summaries', async () => {

--- a/packages/bumpy/test/core/publish-pipeline.test.ts
+++ b/packages/bumpy/test/core/publish-pipeline.test.ts
@@ -62,6 +62,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
       ],
     };
@@ -105,6 +107,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
       ],
     };
@@ -144,6 +148,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
       ],
     };
@@ -192,6 +198,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
         {
           name: 'app',
@@ -201,6 +209,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: true,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
       ],
     };
@@ -239,6 +249,8 @@ describe('publishPackages', () => {
           bumpFiles: [],
           isDependencyBump: false,
           isCascadeBump: false,
+          isGroupBump: false,
+          bumpSources: [],
         },
       ],
     };

--- a/packages/bumpy/test/core/release-plan.test.ts
+++ b/packages/bumpy/test/core/release-plan.test.ts
@@ -92,6 +92,8 @@ describe('assembleReleasePlan', () => {
       const pluginRelease = plan.releases.find((r) => r.name === 'plugin')!;
       expect(pluginRelease.type).toBe('major'); // matches the triggering bump
       expect(pluginRelease.isDependencyBump).toBe(true);
+      expect(pluginRelease.bumpSources).toEqual([{ name: 'core', newVersion: '2.0.0' }]);
+      expect(pluginRelease.bumpFiles).toEqual([]); // no inherited bump files
     });
 
     test('out-of-range regular dep gets patch', () => {
@@ -242,6 +244,21 @@ describe('assembleReleasePlan', () => {
         expect(r.type).toBe('minor');
         expect(r.newVersion).toBe('1.1.0');
       }
+
+      // pkg-b was upgraded from patch to minor, pkg-c was added — both should have group bump info
+      const pkgB = plan.releases.find((r) => r.name === 'pkg-b')!;
+      expect(pkgB.isGroupBump).toBe(true);
+      expect(pkgB.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0' }]);
+      expect(pkgB.bumpFiles).toEqual(['cs2']); // keeps its own direct bump file
+
+      const pkgC = plan.releases.find((r) => r.name === 'pkg-c')!;
+      expect(pkgC.isGroupBump).toBe(true);
+      expect(pkgC.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0' }]);
+      expect(pkgC.bumpFiles).toEqual([]); // no direct bump files
+
+      // pkg-a drove the bump — not a group bump itself
+      const pkgA = plan.releases.find((r) => r.name === 'pkg-a')!;
+      expect(pkgA.isGroupBump).toBe(false);
     });
 
     test('fixed group re-applied after propagation', () => {
@@ -288,6 +305,11 @@ describe('assembleReleasePlan', () => {
       const pluginB = plan.releases.find((r) => r.name === 'plugin-b')!;
       expect(pluginA.type).toBe('minor');
       expect(pluginB.type).toBe('minor');
+      expect(pluginB.isGroupBump).toBe(true);
+      expect(pluginB.bumpSources).toEqual([
+        { name: 'core', newVersion: '1.1.0' }, // from out-of-range dep bump
+        { name: 'plugin-a', newVersion: '2.1.0' }, // from linked group upgrade
+      ]);
     });
   });
 
@@ -318,7 +340,9 @@ describe('assembleReleasePlan', () => {
 
       expect(plan.releases).toHaveLength(3);
       expect(plan.releases.find((r) => r.name === 'unrelated')).toBeUndefined();
-      expect(plan.releases.find((r) => r.name === 'plugin-a')!.type).toBe('patch');
+      const pluginA = plan.releases.find((r) => r.name === 'plugin-a')!;
+      expect(pluginA.type).toBe('patch');
+      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
     });
 
     test('proactive propagation with updateInternalDependencies: "patch"', () => {
@@ -383,8 +407,11 @@ describe('assembleReleasePlan', () => {
       const pluginB = plan.releases.find((r) => r.name === 'plugin-b')!;
       expect(pluginA.type).toBe('patch');
       expect(pluginA.isCascadeBump).toBe(true);
+      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
+      expect(pluginA.bumpFiles).toEqual([]); // no inherited bump files
       expect(pluginB.type).toBe('patch');
       expect(pluginB.isCascadeBump).toBe(true);
+      expect(pluginB.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
     });
 
     test('devDependencies do not propagate by default', () => {

--- a/packages/bumpy/test/helpers.ts
+++ b/packages/bumpy/test/helpers.ts
@@ -54,7 +54,12 @@ export function makeConfig(overrides: Partial<BumpyConfig> = {}): BumpyConfig {
 export function makeRelease(
   name: string,
   newVersion: string,
-  opts: Partial<Pick<PlannedRelease, 'type' | 'oldVersion' | 'bumpFiles' | 'isDependencyBump' | 'isCascadeBump'>> = {},
+  opts: Partial<
+    Pick<
+      PlannedRelease,
+      'type' | 'oldVersion' | 'bumpFiles' | 'isDependencyBump' | 'isCascadeBump' | 'isGroupBump' | 'bumpSources'
+    >
+  > = {},
 ): PlannedRelease {
   return {
     name,
@@ -64,6 +69,8 @@ export function makeRelease(
     bumpFiles: opts.bumpFiles ?? [],
     isDependencyBump: opts.isDependencyBump ?? false,
     isCascadeBump: opts.isCascadeBump ?? false,
+    isGroupBump: opts.isGroupBump ?? false,
+    bumpSources: opts.bumpSources ?? [],
   };
 }
 


### PR DESCRIPTION
## Summary

- When a package is bumped via dependency propagation, cascade rules, or fixed/linked groups, the changelog now shows **which package triggered the bump** and its new version, instead of inheriting the source package's change descriptions
- Adds `bumpSources` field to `PlannedRelease` tracking source packages with their resolved new versions
- Adds `isGroupBump` flag for fixed/linked group bumps
- Each applicable reason (dependency, group, cascade) is shown independently, so overlapping scenarios display all relevant context

### Changelog examples

**Dependency bump:** `- Updated dependency \`core\` v2.0.0`
**Cascade bump:** `- Version bump from \`core\` v1.1.0`
**Group bump:** `- Version bump from group with \`core\` v1.1.0`
**Direct changes + group upgrade:** shows both the direct change and the group explanation

## Test plan

- [x] 212 tests pass (454 assertions)
- [x] Release-plan tests verify `bumpSources` and `isGroupBump` for dependency, cascade, fixed group, and linked group bumps
- [x] Changelog formatter tests (default + github) cover all bump types, fallbacks, and overlap scenarios