### PR TITLE
Fix changelog dep bump tag showing incorrect bump level

### DIFF
--- a/.bumpy/fix-dep-bump-type-tag.md
+++ b/.bumpy/fix-dep-bump-type-tag.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix changelog dependency bump tag showing incorrect bump level

--- a/packages/bumpy/src/core/changelog-github.ts
+++ b/packages/bumpy/src/core/changelog-github.ts
@@ -1,4 +1,6 @@
 import { tryRunArgs } from '../utils/shell.ts';
+import type { BumpType } from '../types.ts';
+import { maxBump } from '../types.ts';
 import type { ChangelogContext, ChangelogFormatter } from './changelog.ts';
 import { getBumpTypeForPackage, sortBumpFilesByType } from './changelog.ts';
 
@@ -100,7 +102,11 @@ export function createGithubFormatter(options: GithubChangelogOptions = {}): Cha
       release.bumpSources.length > 0 ? release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ') : '';
 
     if (release.isDependencyBump) {
-      const depTag = release.type !== 'patch' ? ` *(patch)* -` : '';
+      const depBumpType = release.bumpSources.reduce<BumpType | undefined>(
+        (max, s) => maxBump(max, s.bumpType),
+        undefined,
+      );
+      const depTag = depBumpType && depBumpType !== release.type ? ` *(${depBumpType})* -` : '';
       lines.push(`-${depTag} Updated dependency ${sourceList || '(internal)'}`);
     }
 

--- a/packages/bumpy/src/core/changelog.ts
+++ b/packages/bumpy/src/core/changelog.ts
@@ -2,7 +2,7 @@ import { resolve, relative } from 'node:path';
 import { realpathSync } from 'node:fs';
 import { log } from '../utils/logger.ts';
 import type { BumpFile, BumpType, PlannedRelease, BumpyConfig } from '../types.ts';
-import { BUMP_LEVELS } from '../types.ts';
+import { BUMP_LEVELS, maxBump } from '../types.ts';
 
 // ---- Formatter interface ----
 
@@ -69,7 +69,11 @@ export const defaultFormatter: ChangelogFormatter = (ctx) => {
     release.bumpSources.length > 0 ? release.bumpSources.map((s) => `\`${s.name}\` v${s.newVersion}`).join(', ') : '';
 
   if (release.isDependencyBump) {
-    const tag = release.type !== 'patch' ? `*(patch)* ` : '';
+    const depBumpType = release.bumpSources.reduce<BumpType | undefined>(
+      (max, s) => maxBump(max, s.bumpType),
+      undefined,
+    );
+    const tag = depBumpType && depBumpType !== release.type ? `*(${depBumpType})* ` : '';
     lines.push(`- ${tag}Updated dependency ${sourceList || '(internal)'}`);
   }
 

--- a/packages/bumpy/src/core/release-plan.ts
+++ b/packages/bumpy/src/core/release-plan.ts
@@ -22,8 +22,8 @@ interface PlannedBump {
   isCascadeBump: boolean;
   isGroupBump: boolean;
   bumpFiles: Set<string>;
-  /** Package names that caused this bump via dependency/cascade/group propagation */
-  bumpSources: Set<string>;
+  /** Package names that caused this bump via dependency/cascade/group propagation, with the bump type they contributed */
+  bumpSources: Map<string, BumpType>;
 }
 
 /**
@@ -71,7 +71,7 @@ export function assembleReleasePlan(
           isCascadeBump: false,
           isGroupBump: false,
           bumpFiles: new Set([bf.id]),
-          bumpSources: new Set(),
+          bumpSources: new Map(),
         });
       }
 
@@ -172,7 +172,7 @@ export function assembleReleasePlan(
               existing.type = newType;
               existing.isGroupBump = true;
               for (const src of groupSources) {
-                if (src !== name) existing.bumpSources.add(src);
+                if (src !== name) existing.bumpSources.set(src, groupBump);
               }
               changed = true;
             }
@@ -183,7 +183,7 @@ export function assembleReleasePlan(
               isCascadeBump: false,
               isGroupBump: true,
               bumpFiles: new Set(),
-              bumpSources: new Set(groupSources.filter((s) => s !== name)),
+              bumpSources: new Map(groupSources.filter((s) => s !== name).map((s) => [s, groupBump])),
             });
             changed = true;
           }
@@ -219,7 +219,7 @@ export function assembleReleasePlan(
             existing.type = newType;
             existing.isGroupBump = true;
             for (const src of groupSources) {
-              if (src !== name) existing.bumpSources.add(src);
+              if (src !== name) existing.bumpSources.set(src, groupBump);
             }
             changed = true;
           }
@@ -328,12 +328,13 @@ export function assembleReleasePlan(
       isDependencyBump: bump.isDependencyBump,
       isCascadeBump: bump.isCascadeBump,
       isGroupBump: bump.isGroupBump,
-      bumpSources: [...bump.bumpSources].map((srcName) => {
+      bumpSources: [...bump.bumpSources].map(([srcName, contributedType]) => {
         const srcBump = planned.get(srcName);
         const srcPkg = packages.get(srcName);
         return {
           name: srcName,
           newVersion: srcPkg && srcBump ? bumpVersion(srcPkg.version, srcBump.type) : 'unknown',
+          bumpType: contributedType,
         };
       }),
     });
@@ -373,7 +374,7 @@ function applyBump(
     existing.type = newType;
     if (isDependencyBump) existing.isDependencyBump = true;
     if (isCascadeBump) existing.isCascadeBump = true;
-    existing.bumpSources.add(sourcePackageName);
+    existing.bumpSources.set(sourcePackageName, type);
     return true;
   }
   planned.set(name, {
@@ -382,7 +383,7 @@ function applyBump(
     isCascadeBump,
     isGroupBump: false,
     bumpFiles: new Set(),
-    bumpSources: new Set([sourcePackageName]),
+    bumpSources: new Map([[sourcePackageName, type]]),
   });
   return true;
 }

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -228,7 +228,7 @@ export interface PlannedRelease {
   isCascadeBump: boolean;
   isGroupBump: boolean;
   /** Packages whose bumps caused this dependency/cascade/group bump, with their new versions */
-  bumpSources: Array<{ name: string; newVersion: string }>;
+  bumpSources: Array<{ name: string; newVersion: string; bumpType: BumpType }>;
 }
 
 export interface ReleasePlan {

--- a/packages/bumpy/test/core/release-plan.test.ts
+++ b/packages/bumpy/test/core/release-plan.test.ts
@@ -92,7 +92,7 @@ describe('assembleReleasePlan', () => {
       const pluginRelease = plan.releases.find((r) => r.name === 'plugin')!;
       expect(pluginRelease.type).toBe('major'); // matches the triggering bump
       expect(pluginRelease.isDependencyBump).toBe(true);
-      expect(pluginRelease.bumpSources).toEqual([{ name: 'core', newVersion: '2.0.0' }]);
+      expect(pluginRelease.bumpSources).toEqual([{ name: 'core', newVersion: '2.0.0', bumpType: 'major' }]);
       expect(pluginRelease.bumpFiles).toEqual([]); // no inherited bump files
     });
 
@@ -248,12 +248,12 @@ describe('assembleReleasePlan', () => {
       // pkg-b was upgraded from patch to minor, pkg-c was added — both should have group bump info
       const pkgB = plan.releases.find((r) => r.name === 'pkg-b')!;
       expect(pkgB.isGroupBump).toBe(true);
-      expect(pkgB.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0' }]);
+      expect(pkgB.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0', bumpType: 'minor' }]);
       expect(pkgB.bumpFiles).toEqual(['cs2']); // keeps its own direct bump file
 
       const pkgC = plan.releases.find((r) => r.name === 'pkg-c')!;
       expect(pkgC.isGroupBump).toBe(true);
-      expect(pkgC.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0' }]);
+      expect(pkgC.bumpSources).toEqual([{ name: 'pkg-a', newVersion: '1.1.0', bumpType: 'minor' }]);
       expect(pkgC.bumpFiles).toEqual([]); // no direct bump files
 
       // pkg-a drove the bump — not a group bump itself
@@ -307,8 +307,8 @@ describe('assembleReleasePlan', () => {
       expect(pluginB.type).toBe('minor');
       expect(pluginB.isGroupBump).toBe(true);
       expect(pluginB.bumpSources).toEqual([
-        { name: 'core', newVersion: '1.1.0' }, // from out-of-range dep bump
-        { name: 'plugin-a', newVersion: '2.1.0' }, // from linked group upgrade
+        { name: 'core', newVersion: '1.1.0', bumpType: 'patch' }, // from out-of-range dep bump
+        { name: 'plugin-a', newVersion: '2.1.0', bumpType: 'minor' }, // from linked group upgrade
       ]);
     });
   });
@@ -342,7 +342,7 @@ describe('assembleReleasePlan', () => {
       expect(plan.releases.find((r) => r.name === 'unrelated')).toBeUndefined();
       const pluginA = plan.releases.find((r) => r.name === 'plugin-a')!;
       expect(pluginA.type).toBe('patch');
-      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
+      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0', bumpType: 'patch' }]);
     });
 
     test('proactive propagation with updateInternalDependencies: "patch"', () => {
@@ -407,11 +407,11 @@ describe('assembleReleasePlan', () => {
       const pluginB = plan.releases.find((r) => r.name === 'plugin-b')!;
       expect(pluginA.type).toBe('patch');
       expect(pluginA.isCascadeBump).toBe(true);
-      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
+      expect(pluginA.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0', bumpType: 'patch' }]);
       expect(pluginA.bumpFiles).toEqual([]); // no inherited bump files
       expect(pluginB.type).toBe('patch');
       expect(pluginB.isCascadeBump).toBe(true);
-      expect(pluginB.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0' }]);
+      expect(pluginB.bumpSources).toEqual([{ name: 'core', newVersion: '1.1.0', bumpType: 'patch' }]);
     });
 
     test('devDependencies do not propagate by default', () => {

--- a/packages/bumpy/test/helpers.ts
+++ b/packages/bumpy/test/helpers.ts
@@ -70,7 +70,7 @@ export function makeRelease(
     isDependencyBump: opts.isDependencyBump ?? false,
     isCascadeBump: opts.isCascadeBump ?? false,
     isGroupBump: opts.isGroupBump ?? false,
-    bumpSources: opts.bumpSources ?? [],
+    bumpSources: (opts.bumpSources ?? []).map((s) => ({ ...s, bumpType: s.bumpType ?? opts.type ?? 'patch' })),
   };
 }
 

--- a/packages/bumpy/test/helpers.ts
+++ b/packages/bumpy/test/helpers.ts
@@ -55,11 +55,10 @@ export function makeRelease(
   name: string,
   newVersion: string,
   opts: Partial<
-    Pick<
-      PlannedRelease,
-      'type' | 'oldVersion' | 'bumpFiles' | 'isDependencyBump' | 'isCascadeBump' | 'isGroupBump' | 'bumpSources'
-    >
-  > = {},
+    Pick<PlannedRelease, 'type' | 'oldVersion' | 'bumpFiles' | 'isDependencyBump' | 'isCascadeBump' | 'isGroupBump'>
+  > & {
+    bumpSources?: Array<{ name: string; newVersion: string; bumpType?: BumpType }>;
+  } = {},
 ): PlannedRelease {
   return {
     name,


### PR DESCRIPTION
## Summary

- The dependency bump tag in changelogs was hardcoded to `*(patch)*` regardless of the actual bump level the dependency contributed
- For example, a peer dependency major bump (with `bumpAs: 'match'`) would incorrectly show `*(patch)* - Updated dependency varlock v1.0.0` even though it caused a major bump
- Now tracks `bumpType` per source in `bumpSources`, and only shows the tag when it differs from the release type (e.g., `*(patch)*` on a minor release where the dep only contributed a patch)

## Test plan

- [x] 212 tests pass (454 assertions)
- [x] Typecheck passes
- [x] Bump file included