### PR TITLE
fix: staged publishing fixes, add provenance config

### DIFF
--- a/.bumpy/fix-readme-url.md
+++ b/.bumpy/fix-readme-url.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fix npm staged publishing docs URL in README


### PR DESCRIPTION
## Summary

- Add `provenance` boolean to `PublishConfig` — attaches Sigstore provenance attestation when publishing via npm (replaces needing `publishArgs: ["--provenance"]`)
- Fix npm staged publishing minimum version: requires npm >= 11.15.0 (was incorrectly set to 11.5.1 — `npm stage` was introduced in 11.15.0)
- Throw hard errors (not warnings) when `provenance` or `npmStaged` are used with a non-npm `publishManager`
- Throw clear error with upgrade instructions when npm version is too old for staged publishing
- Add `npm install -g npm@latest` step to release workflow
- Enable both `provenance` and `npmStaged` in bumpy's own config
- Patch bump to republish README with corrected docs URL

## Test plan

- [x] All 6 publish-pipeline tests pass
- [x] Typecheck passes
- [ ] Merge → version PR → merge version PR → staged publish with provenance