### PR TITLE
fix: add provenance config, fix staged publishing version check

### DIFF
--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -10,6 +10,7 @@
   // narrows down which files are considered changes
   "changedFilePatterns": ["src/**", "skills/**", "package.json", "tsconfig.json", "tsdown.config.ts"],
   "publish": {
+    "provenance": true,
     "npmStaged": true
   }
 }

--- a/.bumpy/fix-staged-provenance.md
+++ b/.bumpy/fix-staged-provenance.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Add provenance config option, fix staged publishing minimum npm version (>= 11.15.0), and throw errors for invalid publish config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
-      # Node.js (npm) is needed for npm publish
+      # Node.js (npm) is needed for npm publish — latest includes npm >= 11.x for OIDC/staged
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
-      - run: npm install -g npm@latest # npm >= 11.15.0 needed for staged publishing
+          node-version: latest
       - run: bun install
 
       # --- You wont need this part ---

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,8 @@ jobs:
       # Node.js (npm) is needed for npm publish
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/* # newer node needed for OIDC
+          node-version: lts/*
+      - run: npm install -g npm@latest # npm >= 11.15.0 needed for staged publishing
       - run: bun install
 
       # --- You wont need this part ---

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write # required for npm trusted publishing (OIDC)
+      id-token: write # required for npm trusted publishing (OIDC) and provenance
     steps:
       - uses: actions/checkout@v6
         with:
@@ -130,6 +130,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
+      - run: npm install -g npm@latest # Node LTS ships with npm 10.x; OIDC/staged needs >= 11.x
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:
@@ -137,7 +138,7 @@ jobs:
           BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }} # PAT so that version PR triggers CI
 ```
 
-> **Trusted publishing setup:** Configure each package on [npmjs.com](https://docs.npmjs.com/trusted-publishers/) → Package Settings → Trusted Publishers → GitHub Actions. Specify your org/user, repo, and the workflow filename (`bumpy-release.yml`). No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1 - bumpy will warn if your version is too old.
+> **Trusted publishing setup:** Configure each package on [npmjs.com](https://docs.npmjs.com/trusted-publishers/) → Package Settings → Trusted Publishers → GitHub Actions. Specify your org/user, repo, and the workflow filename (`bumpy-release.yml`). No `NPM_TOKEN` secret needed. Enable `provenance` and `npmStaged` in your [publish config](https://github.com/dmno-dev/bumpy/blob/main/docs/configuration.md#staged-publishing) for maximum security.
 
 <details>
 <summary>Alternative: token-based auth (NPM_TOKEN secret)</summary>

--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
-      - run: npm install -g npm@latest # Node LTS ships with npm 10.x; OIDC/staged needs >= 11.x
+          node-version: latest # Node LTS ships with npm 10.x; latest includes npm >= 11.x for OIDC/staged
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,8 +66,9 @@ The `publish` object controls how packages are packed and published:
 | -------------------- | ---------------------- | -------- | --------------------------------------------------------------------- |
 | `packManager`        | `string`               | `"auto"` | Which package manager packs tarballs (`"auto"` detects from lockfile) |
 | `publishManager`     | `string`               | `"npm"`  | Which tool runs `publish` (npm supports OIDC/provenance)              |
-| `publishArgs`        | `string[]`             | `[]`     | Extra args passed to publish (e.g., `["--provenance"]`)               |
+| `publishArgs`        | `string[]`             | `[]`     | Extra args passed to the publish command                              |
 | `protocolResolution` | `"pack" \| "in-place"` | `"pack"` | How `workspace:` and `catalog:` protocols are resolved                |
+| `provenance`         | `boolean`              | `false`  | Attach provenance attestation via npm (requires OIDC CI environment)  |
 | `npmStaged`          | `boolean`              | `false`  | Use `npm stage publish` — requires 2FA approval on npmjs.com          |
 
 #### Staged publishing
@@ -77,12 +78,13 @@ When `npmStaged` is enabled, bumpy uses `npm stage publish` instead of `npm publ
 Requirements:
 
 - `publishManager` must be `"npm"` (the default)
-- npm >= 11.5.1
-- [npm trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/) configured for your repo
+- npm >= 11.15.0
+- The package must already exist on the npm registry (first publish cannot be staged)
 
 ```json
 {
   "publish": {
+    "provenance": true,
     "npmStaged": true
   }
 }
@@ -230,6 +232,7 @@ See the [Changelog Formatters](./changelog-formatters.md) docs for full details 
     "peerDependencies": { "trigger": "minor", "bumpAs": "match" }
   },
   "publish": {
+    "provenance": true,
     "npmStaged": true
   },
   "aggregateRelease": true,

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -33,9 +33,9 @@ jobs:
 
 ## Release workflow
 
-### Trusted publishing (OIDC ��� recommended)
+### Trusted publishing (OIDC — recommended)
 
-No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1 (>= 11.15.0 for staged publishing).
+No `NPM_TOKEN` secret needed. Node LTS ships with an older npm, so an upgrade step is needed for OIDC (>= 11.5.1) and staged publishing (>= 11.15.0).
 
 ```yaml
 # .github/workflows/bumpy-release.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write # required for npm trusted publishing (OIDC)
+      id-token: write # required for npm trusted publishing (OIDC) and provenance
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
+      - run: npm install -g npm@latest # Node LTS ships with npm 10.x; OIDC/staged needs >= 11.x
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:
@@ -72,7 +73,18 @@ jobs:
 
 **Trusted publishing setup:** Configure each package on [npmjs.com](https://docs.npmjs.com/trusted-publishers/) → Package Settings → Trusted Publishers → GitHub Actions. Specify your org/user, repo, and the workflow filename (`bumpy-release.yml`).
 
-> **Staged publishing:** For an extra layer of security, enable `npmStaged` in your [publish config](./configuration.md#staged-publishing). This uses `npm stage publish` to stage packages on npmjs.com, requiring manual 2FA approval before they go live — even if your CI credentials are compromised, nothing gets published without maintainer approval.
+**Recommended publish config** — enable provenance and staged publishing for maximum security:
+
+```json
+{
+  "publish": {
+    "provenance": true,
+    "npmStaged": true
+  }
+}
+```
+
+> **Staged publishing:** With `npmStaged` enabled, bumpy uses `npm stage publish` to stage packages on npmjs.com, requiring manual 2FA approval before they go live — even if your CI credentials are compromised, nothing gets published without maintainer approval. See the [staged publishing docs](./configuration.md#staged-publishing) for details.
 
 ### Token-based auth (NPM_TOKEN)
 
@@ -146,6 +158,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
+      - run: npm install -g npm@latest
       - run: bun install
 
       - id: plan

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -35,7 +35,7 @@ jobs:
 
 ### Trusted publishing (OIDC — recommended)
 
-No `NPM_TOKEN` secret needed. Node LTS ships with an older npm, so an upgrade step is needed for OIDC (>= 11.5.1) and staged publishing (>= 11.15.0).
+No `NPM_TOKEN` secret needed. Use `node-version: latest` (not `lts/*`) since Node LTS ships with npm 10.x, while OIDC requires >= 11.5.1 and staged publishing requires >= 11.15.0.
 
 ```yaml
 # .github/workflows/bumpy-release.yml
@@ -62,8 +62,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
-      - run: npm install -g npm@latest # Node LTS ships with npm 10.x; OIDC/staged needs >= 11.x
+          node-version: latest # Node LTS ships with npm 10.x; latest includes npm >= 11.x for OIDC/staged
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:
@@ -157,8 +156,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
-      - run: npm install -g npm@latest
+          node-version: latest
       - run: bun install
 
       - id: plan

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -35,7 +35,7 @@ jobs:
 
 ### Trusted publishing (OIDC ��� recommended)
 
-No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1.
+No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1 (>= 11.15.0 for staged publishing).
 
 ```yaml
 # .github/workflows/bumpy-release.yml

--- a/packages/bumpy/src/core/publish-pipeline.ts
+++ b/packages/bumpy/src/core/publish-pipeline.ts
@@ -43,6 +43,20 @@ const OIDC_NPM_UPGRADE_HINTS: Record<string, string> = {
   circleci: 'Use a Node.js image with npm >= 11.5.1 or run `sudo npm install -g npm@latest`',
 };
 
+/** Compare semver triples: returns true if version >= minimum */
+function npmVersionAtLeast(version: string, minimum: [number, number, number]): boolean {
+  const [major, minor, patch] = version.split('.').map(Number);
+  const [minMajor, minMinor, minPatch] = minimum;
+  if (major! > minMajor) return true;
+  if (major! < minMajor) return false;
+  if (minor! > minMinor) return true;
+  if (minor! < minMinor) return false;
+  return patch! >= minPatch;
+}
+
+const MIN_NPM_OIDC: [number, number, number] = [11, 5, 1];
+const MIN_NPM_STAGED: [number, number, number] = [11, 15, 0];
+
 /**
  * Set up npm authentication for publishing.
  *
@@ -73,10 +87,8 @@ function setupNpmAuth(rootDir: string, publishManager: string): void {
   if (oidcProvider) {
     const npmVersion = tryRunArgs(['npm', '--version']);
     if (npmVersion) {
-      const [major, minor, patch] = npmVersion.split('.').map(Number);
-      const meetsMinVersion = major! > 11 || (major === 11 && (minor! > 5 || (minor === 5 && patch! >= 1)));
-      if (!meetsMinVersion) {
-        log.warn(`  npm ${npmVersion} detected — trusted publishing (OIDC) requires npm >= 11.5.1`);
+      if (!npmVersionAtLeast(npmVersion, MIN_NPM_OIDC)) {
+        log.warn(`  npm ${npmVersion} detected — trusted publishing (OIDC) requires npm >= ${MIN_NPM_OIDC.join('.')}`);
         log.warn(`  ${OIDC_NPM_UPGRADE_HINTS[oidcProvider]}`);
       } else {
         log.dim(`  OIDC detected (${oidcProvider}) — npm ${npmVersion} will authenticate via trusted publishing`);
@@ -132,22 +144,26 @@ export async function publishPackages(
   // Set up npm authentication before publishing
   setupNpmAuth(rootDir, publishConfig.publishManager);
 
-  // Validate staged publishing config
+  // Validate npm-specific publish options
+  if (publishConfig.provenance && publishConfig.publishManager !== 'npm') {
+    throw new Error('provenance requires publishManager "npm" — provenance attestation is an npm-specific feature');
+  }
+
   if (publishConfig.npmStaged) {
     if (publishConfig.publishManager !== 'npm') {
-      log.warn('Staged publishing is only supported with publishManager "npm" — ignoring staged option');
-    } else {
-      const npmVersion = tryRunArgs(['npm', '--version']);
-      if (npmVersion) {
-        const [major, minor, patch] = npmVersion.split('.').map(Number);
-        const meetsMinVersion = major! > 11 || (major === 11 && (minor! > 5 || (minor === 5 && patch! >= 1)));
-        if (!meetsMinVersion) {
-          log.warn(`Staged publishing requires npm >= 11.5.1 (found ${npmVersion})`);
-        } else {
-          log.dim(`Staged publishing enabled — packages will require 2FA approval on npmjs.com`);
-        }
-      }
+      throw new Error('npmStaged requires publishManager "npm" — staged publishing is an npm-specific feature');
     }
+    const npmVersion = tryRunArgs(['npm', '--version']);
+    if (!npmVersion) {
+      throw new Error(`npmStaged is enabled but npm was not found — install npm >= ${MIN_NPM_STAGED.join('.')}`);
+    }
+    if (!npmVersionAtLeast(npmVersion, MIN_NPM_STAGED)) {
+      throw new Error(
+        `npmStaged requires npm >= ${MIN_NPM_STAGED.join('.')} (found ${npmVersion})\n` +
+          `  Upgrade npm: npm install -g npm@latest`,
+      );
+    }
+    log.dim(`Staged publishing enabled — packages will require 2FA approval on npmjs.com`);
   }
 
   // Resolve "auto" pack manager to detected PM
@@ -341,7 +357,12 @@ function buildPublishArgs(
   // Dist tag
   if (opts.tag) args.push('--tag', opts.tag);
 
-  // Extra user-configured args (e.g., --provenance)
+  // Provenance attestation
+  if (config.publish.provenance && publishManager === 'npm') {
+    args.push('--provenance');
+  }
+
+  // Extra user-configured args
   if (config.publish.publishArgs.length > 0) {
     args.push(...config.publish.publishArgs);
   }

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -80,9 +80,16 @@ export interface PublishConfig {
    */
   protocolResolution: 'pack' | 'in-place' | 'none';
   /**
+   * Attach provenance attestation when publishing via npm.
+   * Requires a supported CI environment with OIDC (GitHub Actions, GitLab CI, etc.).
+   * Only works with publishManager "npm".
+   * Default: false
+   */
+  provenance: boolean;
+  /**
    * Use npm staged publishing (`npm stage publish`).
    * Stages the publish on npmjs.com, requiring manual 2FA approval before going live.
-   * Only works with publishManager "npm" and requires npm >= 11.5.1.
+   * Only works with publishManager "npm" and requires npm >= 11.15.0.
    * Default: false
    */
   npmStaged: boolean;
@@ -164,6 +171,7 @@ export const DEFAULT_PUBLISH_CONFIG: PublishConfig = {
   packManager: 'auto',
   publishManager: 'npm',
   publishArgs: [],
+  provenance: false,
   npmStaged: false,
   protocolResolution: 'pack',
 };

--- a/packages/bumpy/test/core/publish-pipeline.test.ts
+++ b/packages/bumpy/test/core/publish-pipeline.test.ts
@@ -279,7 +279,7 @@ describe('publishPackages', () => {
     await setupGitRepo();
 
     // Mock npm --version (for staged validation) and the publish command
-    addMockRule({ match: 'npm --version', response: '11.5.1' });
+    addMockRule({ match: 'npm --version', response: '11.15.0' });
     addMockRule({ match: 'npm stage publish', response: '' });
 
     const packages = new Map<string, WorkspacePackage>();


### PR DESCRIPTION
## Summary

- Add `provenance` boolean to `PublishConfig` — first-class option to attach Sigstore provenance attestation (replaces `publishArgs: ["--provenance"]`)
- Fix npm staged publishing minimum version: `npm stage` was introduced in **npm 11.15.0** (not 11.5.1 which is the OIDC minimum)
- Throw hard errors (not warnings) when `provenance` or `npmStaged` are used with a non-npm `publishManager`
- Throw clear error with upgrade instructions when npm version is too old for staged publishing
- Add `npm install -g npm@latest` to release workflow to ensure npm >= 11.15.0
- Enable `provenance: true` in bumpy's own `.bumpy/_config.json`
- Update docs with new option and corrected version requirements

## Test plan

- [x] All 6 publish-pipeline tests pass
- [x] Typecheck passes
- [ ] Merge → version PR → merge version PR → staged publish with provenance succeeds