### PR TITLE
fix: add npm upgrade step for staged publishing

### DIFF
--- a/.bumpy/npm-upgrade-step.md
+++ b/.bumpy/npm-upgrade-step.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': none
+---
+
+true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
-      # Node.js (npm) is needed for npm publish — latest includes npm >= 11.x for OIDC/staged
+      # Node.js (npm) is needed for npm publish
       - uses: actions/setup-node@v6
         with:
           node-version: latest
+      - run: npm install -g npm@latest # ensure npm >= 11.15.0 for staged publishing
       - run: bun install
 
       # --- You wont need this part ---

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: latest # Node LTS ships with npm 10.x; latest includes npm >= 11.x for OIDC/staged
+          node-version: latest
+      - run: npm install -g npm@latest # ensure npm >= 11.15.0 for OIDC/staged publishing
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -35,7 +35,7 @@ jobs:
 
 ### Trusted publishing (OIDC — recommended)
 
-No `NPM_TOKEN` secret needed. Use `node-version: latest` (not `lts/*`) since Node LTS ships with npm 10.x, while OIDC requires >= 11.5.1 and staged publishing requires >= 11.15.0.
+No `NPM_TOKEN` secret needed. Requires npm >= 11.5.1 for OIDC (>= 11.15.0 for staged publishing) — add `npm install -g npm@latest` since even Node latest may not ship with a new enough npm.
 
 ```yaml
 # .github/workflows/bumpy-release.yml
@@ -62,7 +62,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: latest # Node LTS ships with npm 10.x; latest includes npm >= 11.x for OIDC/staged
+          node-version: latest
+      - run: npm install -g npm@latest # ensure npm >= 11.15.0 for OIDC/staged publishing
       - run: bun install
       - run: bunx @varlock/bumpy ci release
         env:
@@ -157,6 +158,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: latest
+      - run: npm install -g npm@latest
       - run: bun install
 
       - id: plan


### PR DESCRIPTION
## Summary

Node latest (v24) ships with npm 11.13.0, which is too old for `npm stage` (introduced in 11.15.0). Add explicit `npm install -g npm@latest` step to:

- Our release workflow
- All documented workflow examples (README, GitHub Actions docs)

This should unblock publishing of 1.9.2 (currently unpublished due to the npm version issue).

## Test plan

- [ ] Merge → CI runs `bumpy ci release` → detects 1.9.2 unpublished → staged publish succeeds with npm >= 11.15.0