### PR TITLE
fix: stream custom build/publish command output and surface real failures

### DIFF
--- a/.bumpy/stream-custom-command-output.md
+++ b/.bumpy/stream-custom-command-output.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Stream `buildCommand`/`publishCommand` output live to the parent process and surface the child's real failure reason. Custom publish commands (vsce, ovsx, anything bespoke) previously ran through a buffering runner that discarded stdout and never streamed output, so a failure like an expired marketplace token produced only a generic `Command failed` wrapper with no usable cause in CI logs. These commands now run through a streaming runner (`spawn` with piped+teed stdio) that prints output as it happens and includes both stdout and stderr in the thrown error. The capturing `runAsync`/`runArgsAsync` helpers (still used for internal git/npm calls whose output is parsed) also now include stdout in their error messages.

--- a/packages/bumpy/src/core/publish-pipeline.ts
+++ b/packages/bumpy/src/core/publish-pipeline.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import { readJson, updateJsonNestedField } from '../utils/fs.ts';
-import { runAsync, runArgsAsync, tryRunArgs, sq } from '../utils/shell.ts';
+import { runStreaming, runArgsAsync, tryRunArgs, sq } from '../utils/shell.ts';
 import { log, colorize } from '../utils/logger.ts';
 import { createTag, tagExists } from './git.ts';
 import { DependencyGraph } from './dep-graph.ts';
@@ -217,7 +217,7 @@ export async function publishPackages(
       if (pkgConfig.buildCommand) {
         log.dim(`  Building...`);
         if (!opts.dryRun) {
-          await runAsync(pkgConfig.buildCommand, { cwd: pkg.dir });
+          await runStreaming(pkgConfig.buildCommand, { cwd: pkg.dir });
         }
       }
 
@@ -243,7 +243,7 @@ export async function publishPackages(
             .replace(/\{\{name\}\}/g, sq(release.name));
           log.dim(`  Running: ${expanded}`);
           if (!opts.dryRun) {
-            await runAsync(expanded, { cwd: pkg.dir });
+            await runStreaming(expanded, { cwd: pkg.dir });
           }
         }
       } else if (!pkgConfig.skipNpmPublish) {

--- a/packages/bumpy/src/utils/shell.ts
+++ b/packages/bumpy/src/utils/shell.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync, exec, execFile } from 'node:child_process';
+import { execSync, execFileSync, exec, execFile, spawn } from 'node:child_process';
 
 /**
  * Escape a value for safe interpolation inside a single-quoted shell string.
@@ -53,7 +53,7 @@ export function runAsync(cmd: string, opts?: { cwd?: string; input?: string }): 
   return new Promise((resolve, reject) => {
     const child = exec(cmd, { cwd: opts?.cwd, encoding: 'utf-8' }, (err, stdout, stderr) => {
       if (err) {
-        reject(new Error(`Command failed: ${cmd}\n${stderr}`));
+        reject(new Error(`Command failed: ${cmd}\n${stdout}\n${stderr}`.trim()));
       } else {
         resolve(stdout.trim());
       }
@@ -62,6 +62,55 @@ export function runAsync(cmd: string, opts?: { cwd?: string; input?: string }): 
       child.stdin?.write(opts.input);
       child.stdin?.end();
     }
+  });
+}
+
+/**
+ * Run a shell command, streaming its stdout/stderr to the parent process live
+ * (so output appears in CI logs as it happens) while also capturing it so the
+ * thrown error on failure includes the child's real output.
+ *
+ * Use this for user-defined commands (build/publish) where we don't need to
+ * parse the output but DO want it visible — unlike the capturing `runAsync`,
+ * which buffers everything and is meant for internal helpers whose stdout we
+ * parse. A failing custom command (e.g. `vsce publish`) writes its real error
+ * to stdout; this surfaces both streams instead of swallowing them.
+ */
+export function runStreaming(cmd: string, opts?: { cwd?: string; input?: string }): Promise<void> {
+  const result = checkIntercept(cmd.split(/\s+/), opts);
+  if (result?.intercepted) {
+    if ('error' in result) return Promise.reject(new Error(result.error));
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, {
+      cwd: opts?.cwd,
+      shell: true,
+      stdio: [opts?.input ? 'pipe' : 'inherit', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk;
+      process.stdout.write(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+      process.stderr.write(chunk);
+    });
+    if (opts?.input) {
+      child.stdin?.write(opts.input);
+      child.stdin?.end();
+    }
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const detail = `${stdout}\n${stderr}`.trim();
+        reject(new Error(`Command failed (exit code ${code}): ${cmd}${detail ? `\n${detail}` : ''}`));
+      }
+    });
   });
 }
 
@@ -102,7 +151,7 @@ export function runArgsAsync(args: string[], opts?: { cwd?: string; input?: stri
   return new Promise((resolve, reject) => {
     const child = execFile(cmd!, rest, { cwd: opts?.cwd, encoding: 'utf-8' }, (err, stdout, stderr) => {
       if (err) {
-        reject(new Error(`Command failed: ${args.join(' ')}\n${stderr}`));
+        reject(new Error(`Command failed: ${args.join(' ')}\n${stdout}\n${stderr}`.trim()));
       } else {
         resolve(stdout.trim());
       }

--- a/packages/bumpy/test/utils/shell.test.ts
+++ b/packages/bumpy/test/utils/shell.test.ts
@@ -1,0 +1,39 @@
+import { test, expect, describe } from 'bun:test';
+import { runStreaming, runAsync, runArgsAsync } from '../../src/utils/shell.ts';
+
+describe('runStreaming', () => {
+  test('resolves for a successful command', async () => {
+    await expect(runStreaming('true')).resolves.toBeUndefined();
+  });
+
+  test('surfaces output written to stdout (not stderr) when a command fails', async () => {
+    // The command writes its real error to stdout, then exits non-zero — this is
+    // exactly the vsce failure mode that used to be swallowed.
+    const cmd = `node -e "console.log('REAL_ERROR_ON_STDOUT'); process.exit(1)"`;
+    await expect(runStreaming(cmd)).rejects.toThrow(/REAL_ERROR_ON_STDOUT/);
+  });
+
+  test('surfaces output written to stderr when a command fails', async () => {
+    const cmd = `node -e "console.error('REAL_ERROR_ON_STDERR'); process.exit(1)"`;
+    await expect(runStreaming(cmd)).rejects.toThrow(/REAL_ERROR_ON_STDERR/);
+  });
+
+  test('includes the exit code and command in the error', async () => {
+    await expect(runStreaming('exit 3')).rejects.toThrow(/exit code 3/);
+  });
+});
+
+describe('runAsync error reporting', () => {
+  test('includes stdout in the thrown error when a command writes its error there', async () => {
+    const cmd = `node -e "console.log('STDOUT_FAILURE_REASON'); process.exit(1)"`;
+    await expect(runAsync(cmd)).rejects.toThrow(/STDOUT_FAILURE_REASON/);
+  });
+});
+
+describe('runArgsAsync error reporting', () => {
+  test('includes stdout in the thrown error when a command writes its error there', async () => {
+    await expect(runArgsAsync(['node', '-e', "console.log('ARGS_STDOUT_FAILURE'); process.exit(1)"])).rejects.toThrow(
+      /ARGS_STDOUT_FAILURE/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

During a release, `@varlock/bumpy` ran user-defined `buildCommand`/`publishCommand` through `runAsync`, which **buffered** all child output (nothing reached CI logs live) and, on failure, threw an error containing only `stderr` — discarding `stdout`. When a custom publish like `vsce publish` wrote its real error (an expired marketplace `VSCE_PAT`) to **stdout** and exited non-zero, the actual cause was invisible — CI showed only a generic `Command failed` wrapper plus bun's exit notice.

This degraded every non-npm / custom publish path (vsce, ovsx, anything bespoke), making failures un-debuggable. npm publishing has its own path and was unaffected.

## Fix

- **New `runStreaming(cmd, opts)`** in `shell.ts` — runs via `spawn` (`shell: true`), **tees** child stdout/stderr to the parent process live so output appears in CI as it happens, while also capturing both streams. On non-zero exit it rejects with `Command failed (exit code N): <cmd>` plus the captured output.
- **`buildCommand` / `publishCommand`** in the publish pipeline now use `runStreaming`. Internal git/npm/pack helpers (which parse captured stdout) stay on the capturing runners, including `checkPublished`.
- **Belt-and-suspenders:** `runAsync` / `runArgsAsync` now include `stdout` (not just `stderr`) in their thrown errors.

## Tests

New `test/utils/shell.test.ts` asserts a command writing its error to **stdout** then exiting non-zero surfaces that text in the rejected error (for `runStreaming`, `runAsync`, and `runArgsAsync`), plus stderr and exit-code coverage.

- `bun run test` → **303 pass, 0 fail**
- `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean

## Acceptance criteria

- [x] A failing `publishCommand` surfaces the child's actual stdout **and** stderr
- [x] `buildCommand`/`publishCommand` output streams live, not just on failure
- [x] Internal git/npm capture-and-parse operations unchanged (full suite passes)
- [x] Unit test for the stdout-only failure case
- [x] Changeset / bump file added (patch → 1.14.1)

## Incident reference

https://github.com/dmno-dev/varlock/actions/runs/27600876636/job/81602352962