### PR TITLE
fix: recover bump files from the version commit even when HEAD has moved past it

### DIFF
--- a/.bumpy/recover-bump-files-past-version-commit.md
+++ b/.bumpy/recover-bump-files-past-version-commit.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Fixed GitHub release notes coming up empty (`No changelog entries.`) when the publish ran several commits after the version commit — e.g. a retry after the first publish was blocked and unrelated fixes landed on main. Bump-file recovery assumed the version commit was always `HEAD~1..HEAD`; it now locates the most recent commit that actually deleted bump files and recovers their content from that commit's parent, so release notes are populated regardless of how far HEAD has moved past versioning.

--- a/packages/bumpy/src/core/bump-file.ts
+++ b/packages/bumpy/src/core/bump-file.ts
@@ -256,22 +256,40 @@ export async function writeBumpFile(
 }
 
 /**
- * Recover bump files that were deleted in the HEAD commit (version commit).
+ * Recover bump files that were deleted by the version commit.
  * Used during the publish-only flow (after version PR merge) to provide
  * bump file context for GitHub release body generation.
+ *
+ * Usually the version commit is HEAD (publish runs right after the version PR
+ * merges), but when publish runs several commits later — e.g. a retry after the
+ * first attempt was blocked and unrelated fixes landed on main — HEAD has moved
+ * past it. So we locate the most recent commit that actually deleted bump files
+ * rather than assuming it's HEAD~1..HEAD; the latter silently recovers nothing
+ * once HEAD diverges, leaving releases with no changelog body.
  */
 export function recoverDeletedBumpFiles(rootDir: string): BumpFile[] {
-  // Find .bumpy/*.md files deleted in the HEAD commit
-  const deleted = tryRunArgs(['git', 'diff', '--diff-filter=D', '--name-only', 'HEAD~1', 'HEAD', '--', '.bumpy/*.md'], {
+  // The most recent commit that deleted any .bumpy/*.md file — i.e. the version
+  // commit that consumed them.
+  const versionCommit = tryRunArgs(['git', 'log', '--diff-filter=D', '--format=%H', '-n', '1', '--', '.bumpy/*.md'], {
     cwd: rootDir,
-  });
+  })
+    ?.split('\n')
+    .filter(Boolean)[0]
+    ?.trim();
+  if (!versionCommit) return [];
+
+  // Read the deleted files' content from the commit's parent.
+  const parent = `${versionCommit}~1`;
+  const deleted = tryRunArgs(
+    ['git', 'diff', '--diff-filter=D', '--name-only', parent, versionCommit, '--', '.bumpy/*.md'],
+    { cwd: rootDir },
+  );
   if (!deleted) return [];
 
   const bumpFiles: BumpFile[] = [];
   for (const filePath of deleted.split('\n').filter(Boolean)) {
     if (filePath.endsWith('README.md')) continue;
-    // Read the file content from the parent commit
-    const content = tryRunArgs(['git', 'show', `HEAD~1:${filePath}`], { cwd: rootDir });
+    const content = tryRunArgs(['git', 'show', `${parent}:${filePath}`], { cwd: rootDir });
     if (!content) continue;
     const { bumpFile } = parseBumpFile(content, fileToId(filePath));
     if (bumpFile) bumpFiles.push(bumpFile);

--- a/packages/bumpy/test/core/bump-file-channels.test.ts
+++ b/packages/bumpy/test/core/bump-file-channels.test.ts
@@ -114,4 +114,28 @@ describe('recoverDeletedBumpFiles with channel dirs', () => {
       await cleanupTempDir(dir);
     }
   });
+
+  test('recovers from the version commit even when HEAD has moved past it', async () => {
+    const dir = await createTempGitRepo();
+    try {
+      await writeBumpFileAt(dir, '.bumpy/feature.md', 'pkg-a', 'minor');
+      gitInDir(['add', '-A'], dir);
+      gitInDir(['commit', '-m', 'add bump file'], dir);
+      gitInDir(['rm', '-r', '.bumpy'], dir);
+      gitInDir(['commit', '-m', 'version packages'], dir);
+      // Unrelated commits land on main after the version commit (e.g. CI fixes
+      // before a publish retry), so the version commit is no longer HEAD.
+      await writeFile(resolve(dir, 'ci-fix.txt'), 'fix');
+      gitInDir(['add', '-A'], dir);
+      gitInDir(['commit', '-m', 'fix ci'], dir);
+      await writeFile(resolve(dir, 'ci-fix-2.txt'), 'fix again');
+      gitInDir(['add', '-A'], dir);
+      gitInDir(['commit', '-m', 'fix ci again'], dir);
+
+      const recovered = recoverDeletedBumpFiles(dir);
+      expect(recovered.map((bf) => bf.id)).toEqual(['feature']);
+    } finally {
+      await cleanupTempDir(dir);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

GitHub release notes came up empty — literally `No changelog entries.` — for a whole batch of releases, even though the `CHANGELOG.md` files had full content. (Observed on a varlock release batch: e.g. [`@varlock/1password-plugin@2.0.0`](https://github.com/dmno-dev/varlock/releases/tag/%40varlock%2F1password-plugin%402.0.0).)

### Root cause

Release bodies are generated at draft-creation time from bump files recovered out of git via `recoverDeletedBumpFiles`. That function only inspected the single `HEAD~1..HEAD` diff, assuming **HEAD is always the version commit** that deleted the bump files.

That assumption breaks when publish runs on a commit *later* than the version commit — e.g. the first publish attempt was blocked, unrelated CI fixes landed on `main`, and publish was retried hours later. By then HEAD has moved past the version commit, the `HEAD~1..HEAD` diff contains no bump-file deletions, recovery returns `[]`, and the release body falls back to the empty placeholder. The `CHANGELOG.md` files are unaffected because they're written and committed at version time.

In the observed case the version commit was 6 commits behind the commit the publish (and the release tags) actually ran on.

## Fix

`recoverDeletedBumpFiles` now locates the **most recent commit that actually deleted `.bumpy/*.md` files** (the version commit) via `git log --diff-filter=D`, and recovers their content from that commit's parent — instead of assuming it's `HEAD~1`.

This is a sound anchor because feature PRs only ever *add* bump files; the only thing that deletes them is a version commit. So "most recent bump-file deletion" is always the version commit for the versions being published, whether that's HEAD (the common case, unchanged behavior) or several commits back. No reliance on parsing `CHANGELOG.md`.

### Known limitation

If two version cycles land before a publish (cycle A versions → publish partially fails → cycle B versions → publish runs), only cycle B's bump files are recovered; packages still pending from cycle A fall back to `No changelog entries.` — same as today, not a regression. Downstream per-package filtering prevents any cross-contamination.

## Tests

- New test: recovery works when HEAD has moved several commits past the version commit.
- Existing HEAD-is-version-commit test still passes (the new query returns HEAD when HEAD is the deleter).
- Full core suite: 327 pass, 0 fail.
