### PR TITLE
feat: ci check fails under pull_request_target without --cwd

### DIFF
--- a/.bumpy/ci-check-cwd-guard.md
+++ b/.bumpy/ci-check-cwd-guard.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': none
+---
+
+`bumpy ci check` now fails when it runs under `pull_request_target` without an explicit `--cwd`, pointing users at the two-checkout workflow. Pass `--cwd .` to acknowledge an already-trusted checkout. Marked `none` because it's part of the `--cwd` feature already shipping in this release.

--- a/.github/workflows/bumpy-check.yaml
+++ b/.github/workflows/bumpy-check.yaml
@@ -1,13 +1,16 @@
 # 🐸 Bumpy CI check
 # checks for missing bump files and posts/updates a PR comment with the release plan
-
+#
 # ⚠️ NOTE - DO NOT COPY THIS FILE
 # instead look at the recommended workflow in the docs
 # ➡️ https://bumpy.varlock.dev/blob/main/docs/github-actions.md ⬅️
 #
-# This repo splits the check into two mutually-exclusive jobs so it can dogfood its
-# OWN unreleased CLI on internal PRs while staying safe for fork PRs. A normal project
-# only needs the single `bunx @varlock/bumpy@latest ci check` job (the fork-safe one).
+# Difference from the recommended workflow: this repo builds and runs its OWN
+# unreleased bumpy (from the trusted `main` checkout) instead of the published
+# @latest, so we dogfood the current CLI on every PR — including forks. The PR
+# head is only ever READ via `--cwd ./pr`; it is never installed, built, or run,
+# so no untrusted code touches the pull_request_target write token. A normal
+# project just runs `bunx @varlock/bumpy@latest ci check --cwd ./pr`.
 
 name: Bumpy Check
 
@@ -18,54 +21,29 @@ permissions:
   contents: read
 
 jobs:
-  # Fork PRs (untrusted): run the PUBLISHED bumpy and never execute the PR's code.
-  # pull_request_target carries a write token + secrets, so building/running fork
-  # code — OR letting the fork's bunfig.toml/.npmrc redirect where bumpy itself is
-  # fetched from — would be a privilege-escalation hole. We fetch+run bumpy from a
-  # trusted base checkout and point it at the PR tree with --cwd. `ci check` only
-  # reads json/yaml. See docs/github-actions.md for the full rationale.
-  check-published:
-    if: github.event.pull_request.head.repo.full_name != github.repository
+  check:
     runs-on: ubuntu-latest
     steps:
-      # 1. Trusted base checkout — bunx runs from here, so the package-manager
-      #    config in effect is ours, not the PR's.
+      # 1. TRUSTED base checkout (main). We build and run bumpy from here, so the
+      #    package-manager config in effect is ours, never the PR's. Safe to
+      #    `bun install` / build because it is our own committed code.
       - uses: actions/checkout@v6
         with:
           ref: main
           persist-credentials: false
-      # 2. Untrusted PR head into ./pr — only READ from here, never resolve/run.
+      # 2. UNTRUSTED PR head into ./pr — only READ via --cwd, never built or run.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
           persist-credentials: false
       - uses: oven-sh/setup-bun@v2
-      - run: bunx @varlock/bumpy@latest ci check --cwd ./pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  # Internal (non-fork) PRs: build and run THIS repo's local bumpy so we dogfood the
-  # unreleased CLI (e.g. channel-aware comments before they're published to @latest).
-  # ⚠️ DO NOT COPY — only safe because the PR head lives in this same repo, so no
-  # untrusted code runs with the privileged token. Forks fall through to check-published.
-  check-local:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 # need history to diff bump files against the PR base branch
-      - uses: oven-sh/setup-bun@v2
       - run: bun install
-      # Build first since we run the local built version of bumpy instead of the published one
+      # Build so we run this repo's bumpy rather than the published one.
       - run: bun run --filter @varlock/bumpy build
-      # run bun install again to make the now-built CLI available
+      # Re-install so the freshly-built CLI bin is linked.
       - run: bun install
-      # `--cwd .` acknowledges that the current checkout is trusted (same-repo PR).
-      # Under pull_request_target, `ci check` requires an explicit --cwd so the old
-      # unsafe single-checkout pattern can't run unnoticed.
-      - run: bunx @varlock/bumpy ci check --cwd .
+      # bunx runs from the trusted root; bumpy reads the PR's bump files via --cwd.
+      - run: bunx @varlock/bumpy ci check --cwd ./pr
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bumpy-check.yaml
+++ b/.github/workflows/bumpy-check.yaml
@@ -5,12 +5,13 @@
 # instead look at the recommended workflow in the docs
 # ➡️ https://bumpy.varlock.dev/blob/main/docs/github-actions.md ⬅️
 #
-# Difference from the recommended workflow: this repo builds and runs its OWN
-# unreleased bumpy (from the trusted `main` checkout) instead of the published
-# @latest, so we dogfood the current CLI on every PR — including forks. The PR
-# head is only ever READ via `--cwd ./pr`; it is never installed, built, or run,
-# so no untrusted code touches the pull_request_target write token. A normal
-# project just runs `bunx @varlock/bumpy@latest ci check --cwd ./pr`.
+# This repo builds and runs its OWN unreleased bumpy so we dogfood the current
+# CLI on every PR. Two jobs, split by trust level:
+#   - non-fork PRs build and run the PR's OWN bumpy, so a PR previews its own
+#     ci-check changes. Safe because the code comes from this repo.
+#   - fork PRs build and run MAIN's bumpy and only READ the PR via `--cwd ./pr`,
+#     so no untrusted code ever touches the pull_request_target write token.
+# A normal project just runs `bunx @varlock/bumpy@latest ci check --cwd ./pr`.
 
 name: Bumpy Check
 
@@ -21,17 +22,38 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  # Non-fork PRs (trusted): build and run the PR's OWN bumpy so it dogfoods its
+  # own changes. `--cwd .` acknowledges that the current checkout is trusted.
+  check-local:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      # 1. TRUSTED base checkout (main). We build and run bumpy from here, so the
-      #    package-manager config in effect is ours, never the PR's. Safe to
-      #    `bun install` / build because it is our own committed code.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # history to diff bump files against the PR base branch
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      # Build first since we run the local built version of bumpy.
+      - run: bun run --filter @varlock/bumpy build
+      # Re-install so the freshly-built CLI bin is linked.
+      - run: bun install
+      - run: bunx @varlock/bumpy ci check --cwd .
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # Fork PRs (untrusted): build and run MAIN's bumpy from a trusted checkout and
+  # only READ the PR head via `--cwd ./pr` — never install/build/run fork code.
+  check-fork:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      # TRUSTED base checkout (main) — bumpy is built and run from here.
       - uses: actions/checkout@v6
         with:
           ref: main
           persist-credentials: false
-      # 2. UNTRUSTED PR head into ./pr — only READ via --cwd, never built or run.
+      # UNTRUSTED PR head into ./pr — only READ via --cwd, never built or run.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -39,9 +61,7 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      # Build so we run this repo's bumpy rather than the published one.
       - run: bun run --filter @varlock/bumpy build
-      # Re-install so the freshly-built CLI bin is linked.
       - run: bun install
       # bunx runs from the trusted root; bumpy reads the PR's bump files via --cwd.
       - run: bunx @varlock/bumpy ci check --cwd ./pr

--- a/.github/workflows/bumpy-check.yaml
+++ b/.github/workflows/bumpy-check.yaml
@@ -63,6 +63,9 @@ jobs:
       - run: bun run --filter @varlock/bumpy build
       # run bun install again to make the now-built CLI available
       - run: bun install
-      - run: bunx @varlock/bumpy ci check
+      # `--cwd .` acknowledges that the current checkout is trusted (same-repo PR).
+      # Under pull_request_target, `ci check` requires an explicit --cwd so the old
+      # unsafe single-checkout pattern can't run unnoticed.
+      - run: bunx @varlock/bumpy ci check --cwd .
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -74,6 +74,8 @@ jobs:
 - **Never execute PR code** — no `bun install` / `npm install` (postinstall scripts run), no `bun run <script>` / `npm test`, no building from the PR tree.
 - **Fetch and run bumpy from the trusted base checkout; only _read_ the PR tree** via `--cwd ./pr`. Keep `persist-credentials: false` on both checkouts.
 
+As a guardrail, `bumpy ci check` **fails** if it runs under `pull_request_target` without an explicit `--cwd` — so an outdated single-checkout workflow surfaces loudly instead of silently staying exploitable. If the working directory is genuinely trusted (e.g. a same-repo, non-fork PR), pass `--cwd .` to acknowledge it. (This is a migration nudge, not a security boundary: a PR that actually hijacked resolution would be running its own bumpy. The fix is the two-checkout layout above.)
+
 > **Using npm / pnpm / yarn?** The same pattern applies — run `npx` / `pnpm dlx` / `yarn dlx` from the trusted root and pass `--cwd ./pr` to bumpy, never the reverse. It matters even more there: pnpm and yarn honor committed config that runs code directly (pnpm's `.pnpmfile.cjs`, yarn's `yarnPath`/`plugins`), not just registry redirects — see the [Turborepo `yarnPath` RCE](https://github.com/vercel/turborepo/security/advisories/GHSA-3qcw-2rhx-2726) for the real-world version.
 
 <details>

--- a/packages/bumpy/src/cli.ts
+++ b/packages/bumpy/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { resolve } from 'node:path';
 import { findRoot } from './core/config.ts';
-import { extractCwdFlag } from './utils/cwd.ts';
+import { extractCwdFlag, pullRequestTargetCwdError } from './utils/cwd.ts';
 import { log, colorize } from './utils/logger.ts';
 
 function parseFlags(args: string[]): Record<string, string | boolean> {
@@ -123,6 +123,16 @@ async function main() {
         const ciFlags = parseFlags(args.slice(2));
 
         if (subcommand === 'check') {
+          // Nudge users still on the old single-checkout pull_request_target
+          // workflow toward the two-checkout + --cwd pattern. See ./utils/cwd.ts.
+          const cwdError = pullRequestTargetCwdError({
+            eventName: process.env.GITHUB_EVENT_NAME,
+            cwdProvided: cwdOverride !== undefined,
+          });
+          if (cwdError) {
+            log.error(cwdError);
+            process.exit(1);
+          }
           const { ciCheckCommand } = await import('./commands/ci.ts');
           await ciCheckCommand(rootDir, {
             comment: ciFlags.comment !== undefined ? ciFlags.comment === true : undefined,

--- a/packages/bumpy/src/utils/cwd.ts
+++ b/packages/bumpy/src/utils/cwd.ts
@@ -43,3 +43,39 @@ export function extractCwdFlag(argv: string[]): CwdParseResult {
   }
   return { cwd, rest };
 }
+
+const DOCS_URL = 'https://github.com/dmno-dev/bumpy/blob/main/docs/github-actions.md';
+
+/**
+ * Return a migration error message if `ci check` is running in the unsafe
+ * `pull_request_target` configuration (no explicit `--cwd`), or `null` if it's
+ * fine. The CLI throws when this returns a string.
+ *
+ * This is a MIGRATION NUDGE, not a security control: a fork PR that successfully
+ * redirected the registry would be running its own replacement bumpy, which has
+ * no such guard. The value is in catching honest users still on the old
+ * single-checkout workflow and pointing them at the two-checkout pattern before
+ * a real attacker exploits it. Passing any `--cwd` (including `--cwd .` to
+ * acknowledge an already-trusted directory) satisfies the check.
+ */
+export function pullRequestTargetCwdError(opts: {
+  eventName: string | undefined;
+  cwdProvided: boolean;
+}): string | null {
+  if (opts.eventName !== 'pull_request_target' || opts.cwdProvided) return null;
+  return [
+    '`bumpy ci check` is running under pull_request_target without --cwd.',
+    '',
+    'This is the unsafe configuration. pull_request_target grants a write token and',
+    'secrets, and the current directory is the (untrusted) PR checkout — so a fork',
+    "PR's bunfig.toml/.npmrc can redirect where bumpy itself is fetched from, at the",
+    'exact version you pinned.',
+    '',
+    'Fix: check the PR head into ./pr from a trusted base checkout, then run',
+    '`bumpy ci check --cwd ./pr`. Updated workflow:',
+    `  ${DOCS_URL}`,
+    '',
+    'If the current directory is already a trusted checkout (e.g. a same-repo,',
+    'non-fork PR), pass `--cwd .` to acknowledge it and continue.',
+  ].join('\n');
+}

--- a/packages/bumpy/test/utils/cwd.test.ts
+++ b/packages/bumpy/test/utils/cwd.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { extractCwdFlag } from '../../src/utils/cwd.ts';
+import { extractCwdFlag, pullRequestTargetCwdError } from '../../src/utils/cwd.ts';
 
 describe('extractCwdFlag', () => {
   test('absent flag returns args unchanged', () => {
@@ -49,5 +49,29 @@ describe('extractCwdFlag', () => {
     const { cwd, rest } = extractCwdFlag(['add', '--cwd', './--cwd-dir']);
     expect(cwd).toBe('./--cwd-dir');
     expect(rest).toEqual(['add']);
+  });
+});
+
+describe('pullRequestTargetCwdError', () => {
+  test('errors under pull_request_target without --cwd', () => {
+    const err = pullRequestTargetCwdError({ eventName: 'pull_request_target', cwdProvided: false });
+    expect(err).toContain('pull_request_target');
+    expect(err).toContain('--cwd ./pr');
+  });
+
+  test('no error when --cwd is provided (even just `--cwd .`)', () => {
+    expect(pullRequestTargetCwdError({ eventName: 'pull_request_target', cwdProvided: true })).toBeNull();
+  });
+
+  test('no error for a plain pull_request event (non-privileged)', () => {
+    expect(pullRequestTargetCwdError({ eventName: 'pull_request', cwdProvided: false })).toBeNull();
+  });
+
+  test('no error for push events', () => {
+    expect(pullRequestTargetCwdError({ eventName: 'push', cwdProvided: false })).toBeNull();
+  });
+
+  test('no error outside CI (no event name)', () => {
+    expect(pullRequestTargetCwdError({ eventName: undefined, cwdProvided: false })).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to #138 — the `--cwd` flag landed there, but this migration guardrail was committed just after the merge, so it needs its own PR.

## What

`bumpy ci check` now **exits 1** when it runs under `GITHUB_EVENT_NAME=pull_request_target` *and* no `--cwd` was passed, printing a message that points at the two-checkout workflow. This makes an outdated single-checkout workflow fail loudly instead of staying silently exploitable.

- Passing any `--cwd` satisfies it. For a genuinely-trusted checkout (e.g. a same-repo, non-fork PR) pass `--cwd .` to acknowledge.
- Scoped narrowly: never fires for plain `pull_request`, `push`, or local runs.
- **Not a security boundary** — a PR that actually hijacked package resolution would be running its own bumpy with no such guard. The value is catching honest users on the old pattern before a real attacker does.

## Changes

- `packages/bumpy/src/utils/cwd.ts` — testable `pullRequestTargetCwdError()`.
- `packages/bumpy/src/cli.ts` — wired into the `ci check` branch.
- `packages/bumpy/test/utils/cwd.test.ts` — +5 tests.
- `.github/workflows/bumpy-check.yaml` — this repo's own `check-local` job now uses `--cwd .` (it runs under `pull_request_target`).
- `docs/github-actions.md` — short note on the guardrail.

## Versioning

`none` bump file (`.bumpy/ci-check-cwd-guard.md`) — it's part of the `--cwd` feature whose `minor` already merged in #138, so it rides the existing pending bump into the next release rather than adding its own.

## Verification

382 tests pass (+5); `bun run check` (lint + fmt + tsc) clean. Manually confirmed the guard exits 1 under `pull_request_target` with no `--cwd`, and passes with `--cwd .` / under `pull_request` / `push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Also: updated our own bumpy-check workflow

Split `.github/workflows/bumpy-check.yaml` into two trust-scoped jobs (only one runs per PR):

- **`check-local` (non-fork PRs):** build and run the PR's **own** bumpy with `--cwd .`, so a PR previews its own ci-check changes (live dogfooding preserved).
- **`check-fork` (fork PRs):** build **main's** bumpy from a trusted checkout, check the fork PR head into `./pr`, and run `ci check --cwd ./pr`. No fork code is installed/built/run.

Both satisfy the new `--cwd` guard (`.` vs `./pr`). This replaces the `--cwd .`-only tweak this PR originally made to `check-local`.

> Note: `pull_request_target` runs the workflow from the **base** branch, so this only takes effect after merge — #140's own check still runs main's current workflow.
