### PR TITLE
ci: rename Bumpy Check job to bumpy-check (fix status-context collision)

### DIFF
--- a/.github/workflows/bumpy-check.yaml
+++ b/.github/workflows/bumpy-check.yaml
@@ -18,7 +18,9 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  # Distinct job name (not "check") so its status context doesn't collide with the
+  # `check` job in ci.yaml. This is the context to require in branch protection.
+  bumpy-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

Re-applies the one commit the [#142](https://github.com/dmno-dev/bumpy/pull/142) squash-merge dropped: renaming the **Bumpy Check** workflow's job from `check` to `bumpy-check`.

## Why

On `main` right now, two PR workflows both emit a status context named `check`:

- `CI / check` (the test suite, in `ci.yaml`)
- `Bumpy Check / check` (the bump-file check, in `bumpy-check.yaml`)

A required status check named `check` is therefore ambiguous. Renaming the bump-file job to `bumpy-check` gives it a distinct context.

## ⚠️ Needs a branch-protection (ruleset) change too

The "Protect main" ruleset currently requires **`check`** and **`check-local`**. Since #142 merged, `check-local` no longer exists (it was the old `pull_request_target` job) → it's now a **phantom required check that blocks every PR**, including this one.

Required checks should become **`check`** (CI tests) + **`bumpy-check`** (this PR's renamed job). The `comment` job in `bumpy-comment.yaml` (the `workflow_run` poster) should **not** be required.

This PR stays blocked until the ruleset drops `check-local`, so the ruleset edit and this merge go together.
