### PR TITLE
feat: directBump:false package flag + fixed-group sync-to-highest

### DIFF
--- a/.bumpy/direct-bump-and-fixed-sync.md
+++ b/.bumpy/direct-bump-and-fixed-sync.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': minor
+---
+
+Added `directBump: false` per-package config for packages that only receive propagated bumps (e.g. platform binary packages in a fixed group with their core package) — they are excluded from `bumpy add`/`bumpy generate`, rejected when a bump file names them directly, and `bumpy check` points at their fixed-group members instead. Fixed groups now sync drifted members to a bump of the group's highest version so they reconverge.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,20 +174,42 @@ Per-package settings can be defined in two places:
 
 `package.json` settings take precedence over global config.
 
-| Option                     | Type                       | Description                                                                            |
-| -------------------------- | -------------------------- | -------------------------------------------------------------------------------------- |
-| `managed`                  | `boolean`                  | Opt this package in or out of versioning                                               |
-| `access`                   | `"public" \| "restricted"` | Override the global access level                                                       |
-| `publishCommand`           | `string \| string[]`       | Custom command(s) to publish this package (replaces npm publish)                       |
-| `buildCommand`             | `string`                   | Command to run before publishing                                                       |
-| `registry`                 | `string`                   | Custom npm registry URL                                                                |
-| `skipNpmPublish`           | `boolean`                  | Don't publish to npm (still creates git tags)                                          |
-| `checkPublished`           | `string`                   | Custom command that outputs the currently published version                            |
-| `changedFilePatterns`      | `string[]`                 | Glob patterns for changed-file detection (replaces root setting, not merged)           |
-| `dependencyBumpRules`      | `object`                   | Per-package override for dependency propagation rules                                  |
-| `cascadeTo`                | `object`                   | Explicit cascade targets — glob pattern mapped to `{ trigger, bumpAs }`                |
-| `cascadeFrom`              | `object`                   | Explicit cascade sources — glob pattern mapped to `{ trigger, bumpAs }`                |
-| `releaseTriggeringDevDeps` | `string[]`                 | devDependencies that affect published output — a change requires a release (see below) |
+| Option                     | Type                       | Description                                                                              |
+| -------------------------- | -------------------------- | ---------------------------------------------------------------------------------------- |
+| `managed`                  | `boolean`                  | Opt this package in or out of versioning                                                 |
+| `directBump`               | `boolean`                  | When `false`, the package only receives propagated bumps — never direct ones (see below) |
+| `access`                   | `"public" \| "restricted"` | Override the global access level                                                         |
+| `publishCommand`           | `string \| string[]`       | Custom command(s) to publish this package (replaces npm publish)                         |
+| `buildCommand`             | `string`                   | Command to run before publishing                                                         |
+| `registry`                 | `string`                   | Custom npm registry URL                                                                  |
+| `skipNpmPublish`           | `boolean`                  | Don't publish to npm (still creates git tags)                                            |
+| `checkPublished`           | `string`                   | Custom command that outputs the currently published version                              |
+| `changedFilePatterns`      | `string[]`                 | Glob patterns for changed-file detection (replaces root setting, not merged)             |
+| `dependencyBumpRules`      | `object`                   | Per-package override for dependency propagation rules                                    |
+| `cascadeTo`                | `object`                   | Explicit cascade targets — glob pattern mapped to `{ trigger, bumpAs }`                  |
+| `cascadeFrom`              | `object`                   | Explicit cascade sources — glob pattern mapped to `{ trigger, bumpAs }`                  |
+| `releaseTriggeringDevDeps` | `string[]`                 | devDependencies that affect published output — a change requires a release (see below)   |
+
+### `directBump: false` — packages that only follow
+
+Some packages are derived artifacts of another package and should never be bumped on their own — the typical case is platform-specific binary packages published alongside a core package (the esbuild/napi-rs pattern, where the core references each binary via exact-version `optionalDependencies`).
+
+Put the binaries in a `fixed` group with the core so they version in lockstep, and mark them `directBump: false` so they can only receive propagated bumps:
+
+```jsonc
+{
+  "fixed": [["mycli", "@mycli/bin-*"]],
+  "packages": {
+    "@mycli/bin-*": { "directBump": false },
+  },
+}
+```
+
+Effects:
+
+- `bumpy add` and `bumpy generate` never select or suggest them — you only ever bump `mycli`, and the fixed group pulls the binaries along.
+- A bump file that directly names one (with a type other than `none`) is an error at plan time.
+- `bumpy check` treats changes in a `directBump: false` package as covered when a bump file covers any other member of its fixed group, and points there when one is missing.
 
 ### Custom commands and `allowCustomCommands`
 

--- a/docs/version-propagation.md
+++ b/docs/version-propagation.md
@@ -73,6 +73,10 @@ Packages in a `fixed` group always share the **same version number**. When any p
 
 Example: propagation bumps `@myorg/types` as patch → `@myorg/core` also gets a patch bump to stay in sync.
 
+Group members version from the group's **highest current version**, not each package's own. If versions have drifted (a botched manual publish, a package added to the group late), the next release syncs every member to a bump of the highest version and reconverges the group — with a warning in the plan explaining the jump.
+
+For groups where one package drives and the others only follow (e.g. platform binary packages alongside a core package), mark the followers with [`directBump: false`](configuration.md#directbump-false--packages-that-only-follow) so they can never be bumped directly — only pulled along by the group.
+
 ### Linked groups
 
 Packages in a `linked` group share the **same bump level** but keep independent version numbers. Only packages already in the release plan are affected — linked groups don't pull in packages that have no bump files. Entries can be specific names or glob patterns.

--- a/packages/bumpy/config-schema.json
+++ b/packages/bumpy/config-schema.json
@@ -318,6 +318,10 @@
           "type": "boolean",
           "description": "Explicitly opt this package in or out of version management"
         },
+        "directBump": {
+          "type": "boolean",
+          "description": "When false, this package can never be bumped directly by a bump file — it only receives propagated bumps (fixed/linked group, cascade, dependency). Use for derived artifacts like platform binary packages kept in a fixed group with their core package."
+        },
         "access": {
           "type": "string",
           "enum": ["public", "restricted"],

--- a/packages/bumpy/src/commands/add.ts
+++ b/packages/bumpy/src/commands/add.ts
@@ -40,7 +40,9 @@ export async function addCommand(rootDir: string, opts: AddOptions): Promise<voi
   if (opts.none) {
     const { packages } = await discoverWorkspace(rootDir, config);
     const changedFiles = getChangedFiles(rootDir, config.baseBranch);
-    const changedPackages = await findChangedPackages(changedFiles, packages, rootDir, config);
+    const changedPackages = (await findChangedPackages(changedFiles, packages, rootDir, config)).filter(
+      (name) => packages.get(name)?.bumpy?.directBump !== false,
+    );
 
     if (changedPackages.length === 0) {
       log.info('No changed packages detected.');
@@ -71,6 +73,15 @@ export async function addCommand(rootDir: string, opts: AddOptions): Promise<voi
   if (opts.packages) {
     // Non-interactive mode
     releases = parsePackagesFlag(opts.packages);
+    const { packages: pkgs } = await discoverWorkspace(rootDir, config);
+    for (const r of releases) {
+      if (r.type !== 'none' && pkgs.get(r.name)?.bumpy?.directBump === false) {
+        throw new Error(
+          `"${r.name}" has "directBump": false — it only receives propagated bumps ` +
+            '(fixed/linked group, cascade, dependency). Bump the package that drives it instead.',
+        );
+      }
+    }
     summary = opts.message || '';
     filename = opts.name ? slugify(opts.name) : randomName();
   } else {
@@ -97,8 +108,14 @@ export async function addCommand(rootDir: string, opts: AddOptions): Promise<voi
       }
     }
 
-    // Build items for the bump select prompt
-    const bumpSelectItems: BumpSelectItem[] = [...pkgs.values()].map((pkg) => {
+    // Build items for the bump select prompt (directBump: false packages are never
+    // directly bumpable — they only follow their group/cascade sources)
+    const selectablePkgs = [...pkgs.values()].filter((pkg) => pkg.bumpy?.directBump !== false);
+    if (selectablePkgs.length === 0) {
+      p.cancel('All managed packages have "directBump": false — nothing to select.');
+      process.exit(1);
+    }
+    const bumpSelectItems: BumpSelectItem[] = selectablePkgs.map((pkg) => {
       const item: BumpSelectItem = {
         name: pkg.name,
         version: pkg.version,

--- a/packages/bumpy/src/commands/check.ts
+++ b/packages/bumpy/src/commands/check.ts
@@ -1,7 +1,7 @@
 import { relative, resolve } from 'node:path';
 import picomatch from 'picomatch';
 import { log, colorize } from '../utils/logger.ts';
-import { loadConfig, loadPackageConfig, getBumpyDir, matchGlob } from '../core/config.ts';
+import { loadConfig, loadPackageConfig, getBumpyDir, matchGlob, resolveFixedGroups } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
 import { readBumpFiles, filterBranchBumpFiles } from '../core/bump-file.ts';
 import { getChangedFiles, getFileStatuses, getBaseCompareRef, readFileAtRef } from '../core/git.ts';
@@ -163,8 +163,15 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
     return;
   }
 
-  // Check which changed packages are missing bump files
-  const missing = changedPackages.filter((name) => !coveredPackages.has(name));
+  // Check which changed packages are missing bump files. Packages with
+  // directBump: false can't have their own bump file — they count as covered
+  // when a fixed-group member is covered, and otherwise point there.
+  const { missing, hints } = resolveDirectBumpCoverage(
+    changedPackages.filter((name) => !coveredPackages.has(name)),
+    coveredPackages,
+    packages,
+    config,
+  );
 
   // An empty bump file covers all remaining packages (in non-strict mode)
   // It acts as a blanket acknowledgment that non-publishable changes are expected
@@ -195,7 +202,8 @@ export async function checkCommand(rootDir: string, opts: CheckOptions = {}): Pr
 
   (willFail ? log.error : log.warn)(`${missing.length} changed package(s) missing bump files:\n`);
   for (const name of missing) {
-    console.log(`  ${colorize(name, 'yellow')}`);
+    const hint = hints.get(name);
+    console.log(`  ${colorize(name, 'yellow')}${hint ? ` — ${hint}` : ''}`);
   }
 
   if (effectiveBumpFiles.length > 0) {
@@ -235,6 +243,42 @@ function printBumpFileList(
           : '';
     log.dim(`  ${bumpyRelDir}/${id}.md${statusLabel}`);
   }
+}
+
+/**
+ * Coverage adjustment for `directBump: false` packages. Such a package never gets its
+ * own bump file — its changes ship by bumping another member of its fixed group. So a
+ * missing directBump package counts as covered when any other fixed-group member is
+ * covered; otherwise it stays missing, with a hint pointing at the bumpable members.
+ */
+export function resolveDirectBumpCoverage(
+  missing: string[],
+  covered: Set<string>,
+  packages: Map<string, WorkspacePackage>,
+  config: BumpyConfig,
+): { missing: string[]; hints: Map<string, string> } {
+  const fixedGroups = resolveFixedGroups(config, packages.keys());
+  const stillMissing: string[] = [];
+  const hints = new Map<string, string>();
+
+  for (const name of missing) {
+    if (packages.get(name)?.bumpy?.directBump !== false) {
+      stillMissing.push(name);
+      continue;
+    }
+    const group = fixedGroups.find((members) => members.includes(name));
+    if (group?.some((member) => member !== name && covered.has(member))) continue;
+
+    stillMissing.push(name);
+    const bumpable = (group ?? []).filter((m) => m !== name && packages.get(m)?.bumpy?.directBump !== false);
+    hints.set(
+      name,
+      bumpable.length > 0
+        ? `has directBump: false — add a bump for its fixed-group member ${bumpable.join(' or ')} instead`
+        : 'has directBump: false — it only receives propagated bumps; add it to a fixed group or bump its cascade source',
+    );
+  }
+  return { missing: stillMissing, hints };
 }
 
 /** Map changed files to the packages they belong to */

--- a/packages/bumpy/src/commands/generate.ts
+++ b/packages/bumpy/src/commands/generate.ts
@@ -68,6 +68,9 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
   // Build scope → package name mapping for CC resolution
   const scopeMap = buildScopeMap(packages, config);
 
+  // Packages with directBump: false only receive propagated bumps — never suggest them
+  const isDirectlyBumpable = (name: string) => packages.get(name)?.bumpy?.directBump !== false;
+
   // Collect releases from all commits
   const releaseMap = new Map<string, { type: BumpType; messages: string[] }>();
 
@@ -84,7 +87,7 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
 
       let pkgNames: string[] = [];
       if (cc.scope) {
-        const resolved = resolveScope(cc.scope, scopeMap, packages);
+        const resolved = resolveScope(cc.scope, scopeMap, packages).filter(isDirectlyBumpable);
         if (resolved.length > 0) {
           pkgNames = resolved;
         }
@@ -101,7 +104,7 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
       // CC commit but scope didn't resolve (or no scope) — use file-based detection
       // with the CC-derived bump level
       const files = getFilesChangedInCommit(commit.hash, { cwd: rootDir });
-      const touchedPkgs = mapFilesToPackages(files, packages, rootDir);
+      const touchedPkgs = mapFilesToPackages(files, packages, rootDir).filter(isDirectlyBumpable);
 
       if (touchedPkgs.length > 0) {
         for (const name of touchedPkgs) {
@@ -113,7 +116,7 @@ export async function generateCommand(rootDir: string, opts: GenerateOptions): P
     } else {
       // Non-conventional commit — use file paths to detect packages, default to patch
       const files = getFilesChangedInCommit(commit.hash, { cwd: rootDir });
-      const touchedPkgs = mapFilesToPackages(files, packages, rootDir);
+      const touchedPkgs = mapFilesToPackages(files, packages, rootDir).filter(isDirectlyBumpable);
 
       if (touchedPkgs.length > 0) {
         fileBasedCount++;

--- a/packages/bumpy/src/core/config.ts
+++ b/packages/bumpy/src/core/config.ts
@@ -88,6 +88,15 @@ function findPackageConfig(config: BumpyConfig, pkgName: string): PackageConfig 
   return {};
 }
 
+/**
+ * Resolve `config.fixed` glob groups to concrete package-name groups.
+ * Returns one entry per configured group (possibly empty if nothing matches).
+ */
+export function resolveFixedGroups(config: BumpyConfig, packageNames: Iterable<string>): string[][] {
+  const names = [...packageNames];
+  return config.fixed.map((group) => names.filter((name) => group.some((pattern) => matchGlob(name, pattern))));
+}
+
 /** Simple glob matching for package names (supports * and **) */
 export function matchGlob(name: string, pattern: string): boolean {
   // Exact match

--- a/packages/bumpy/src/core/release-plan.ts
+++ b/packages/bumpy/src/core/release-plan.ts
@@ -1,6 +1,6 @@
-import { matchGlob } from './config.ts';
+import { matchGlob, resolveFixedGroups } from './config.ts';
 import { DependencyGraph } from './dep-graph.ts';
-import { bumpVersion, satisfies } from './semver.ts';
+import { bumpVersion, compareVersions, satisfies } from './semver.ts';
 import {
   type BumpyConfig,
   type BumpType,
@@ -64,8 +64,32 @@ export function assembleReleasePlan(
   const planned = new Map<string, PlannedBump>();
   const warnings: string[] = [];
 
+  // Fixed groups resolved to concrete members, and a member → group lookup.
+  // Members of a fixed group version from the group's highest current version
+  // (sync-to-highest), so drifted groups reconverge instead of bumping in parallel.
+  const fixedGroups = resolveFixedGroups(config, packages.keys());
+  const fixedGroupOf = new Map<string, string[]>();
+  for (const members of fixedGroups) {
+    for (const member of members) {
+      if (!fixedGroupOf.has(member)) fixedGroupOf.set(member, members);
+    }
+  }
+
+  /** The version a package bumps from: its own, or the highest in its fixed group. */
+  const versionBase = (name: string): string => {
+    const members = fixedGroupOf.get(name);
+    if (!members) return packages.get(name)!.version;
+    let max = packages.get(name)!.version;
+    for (const member of members) {
+      const v = packages.get(member)!.version;
+      if (compareVersions(v, max) > 0) max = v;
+    }
+    return max;
+  };
+
   // Step 1: Collect explicit bumps from bump files
   const cascadeOverrides = new Map<string, Map<string, BumpType>>(); // pkg → (glob → bumpType)
+  const directBumpViolations: string[] = [];
 
   for (const bf of bumpFiles) {
     for (const release of bf.releases) {
@@ -75,6 +99,12 @@ export function assembleReleasePlan(
       // 'none' means "no direct bump needed" — just skip it.
       // Cascading bumps from other packages can still add this package later.
       if (bump === 'none') continue;
+
+      // Packages with directBump: false only receive propagated bumps
+      if (packages.get(release.name)!.bumpy?.directBump === false) {
+        directBumpViolations.push(`  ${bf.id}.md → ${release.name}: ${bump}`);
+        continue;
+      }
 
       const existing = planned.get(release.name);
       if (existing) {
@@ -105,6 +135,15 @@ export function assembleReleasePlan(
     }
   }
 
+  if (directBumpViolations.length > 0) {
+    throw new Error(
+      'Bump file(s) directly bump package(s) configured with "directBump": false — ' +
+        'these packages only receive propagated bumps (fixed/linked group, cascade, dependency):\n' +
+        `${directBumpViolations.join('\n')}\n` +
+        'Bump the package that drives them instead (e.g. their fixed-group member), or use type "none".',
+    );
+  }
+
   // Step 2: Propagation loop (iterative until stable)
   let changed = true;
   let iterations = 0;
@@ -117,7 +156,7 @@ export function assembleReleasePlan(
     // Phase A: Fix out-of-range dependencies (always runs)
     for (const [pkgName, bump] of planned) {
       const pkg = packages.get(pkgName)!;
-      const newVersion = bumpVersion(pkg.version, bump.type);
+      const newVersion = bumpVersion(versionBase(pkgName), bump.type);
       // On a channel, the published version carries a prerelease suffix — check
       // range satisfaction against that, since prereleases never satisfy normal ranges
       const versionForRangeCheck = opts.prereleasePreid ? `${newVersion}-${opts.prereleasePreid}.0` : newVersion;
@@ -326,13 +365,26 @@ export function assembleReleasePlan(
     }
   }
 
+  // Warn when a fixed group with planned releases has drifted versions — members
+  // are synced to a bump of the group's highest version, so some may jump.
+  for (const members of fixedGroups) {
+    const plannedMembers = members.filter((m) => planned.has(m));
+    if (plannedMembers.length === 0) continue;
+    const versions = new Set(members.map((m) => packages.get(m)!.version));
+    if (versions.size > 1) {
+      const detail = members.map((m) => `${m}@${packages.get(m)!.version}`).join(', ');
+      const target = bumpVersion(versionBase(members[0]!), planned.get(plannedMembers[0]!)!.type);
+      warnings.push(`Fixed group versions have drifted (${detail}) — syncing all members to ${target}.`);
+    }
+  }
+
   // Step 3: Calculate new versions
   const releases: PlannedRelease[] = [];
   for (const [name, bump] of planned) {
     const pkg = packages.get(name);
     if (!pkg) continue;
 
-    const newVersion = bumpVersion(pkg.version, bump.type);
+    const newVersion = bumpVersion(versionBase(name), bump.type);
     releases.push({
       name,
       type: bump.type,
@@ -347,7 +399,7 @@ export function assembleReleasePlan(
         const srcPkg = packages.get(srcName);
         return {
           name: srcName,
-          newVersion: srcPkg && srcBump ? bumpVersion(srcPkg.version, srcBump.type) : 'unknown',
+          newVersion: srcPkg && srcBump ? bumpVersion(versionBase(srcName), srcBump.type) : 'unknown',
           bumpType: contributedType,
         };
       }),

--- a/packages/bumpy/src/types.ts
+++ b/packages/bumpy/src/types.ts
@@ -197,6 +197,19 @@ export interface BumpyConfig {
 export interface PackageConfig {
   /** Explicitly opt in or out of version management (overrides private/ignore/include) */
   managed?: boolean;
+  /**
+   * When `false`, this package can never be bumped directly by a bump file — it only
+   * receives propagated bumps (fixed/linked groups, cascades, dependency updates).
+   *
+   * Use this for derived artifacts that version in lockstep with a driver package —
+   * the typical case is platform-specific binary packages (`@mycli/bin-*`) published
+   * alongside a core package and kept in a `fixed` group with it. Effects:
+   * - `bumpy add` / `bumpy generate` never select or suggest the package
+   * - a bump file that directly names it (with a type other than `none`) is an error
+   * - `bumpy check` considers its changes covered when a bump file covers any other
+   *   member of its fixed group, and points there when one is missing
+   */
+  directBump?: boolean;
   access?: 'public' | 'restricted';
   publishCommand?: string | string[];
   buildCommand?: string;

--- a/packages/bumpy/test/core/check.test.ts
+++ b/packages/bumpy/test/core/check.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { resolve } from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { extractBumpFileIdsFromChangedFiles, filterBranchBumpFiles } from '../../src/core/bump-file.ts';
-import { findChangedPackages } from '../../src/commands/check.ts';
+import { findChangedPackages, resolveDirectBumpCoverage } from '../../src/commands/check.ts';
 import { makeBumpFile, makePkg, makeConfig } from '../helpers.ts';
 
 describe('extractBumpFileIdsFromChangedFiles', () => {
@@ -131,5 +131,40 @@ describe('findChangedPackages', () => {
 
     const result = await findChangedPackages(changed, packages, rootDir, makeConfig());
     expect(result).toEqual(['pkg-a']);
+  });
+});
+
+describe('resolveDirectBumpCoverage', () => {
+  const packages = new Map([
+    ['cli', makePkg('cli', '1.0.0')],
+    ['@cli/bin-darwin', makePkg('@cli/bin-darwin', '1.0.0', { bumpy: { directBump: false } })],
+    ['@cli/bin-linux', makePkg('@cli/bin-linux', '1.0.0', { bumpy: { directBump: false } })],
+    ['other', makePkg('other', '1.0.0')],
+  ]);
+  const config = makeConfig({ fixed: [['cli', '@cli/bin-*']] });
+
+  test('normal packages pass through unchanged', () => {
+    const { missing, hints } = resolveDirectBumpCoverage(['other'], new Set(), packages, config);
+    expect(missing).toEqual(['other']);
+    expect(hints.size).toBe(0);
+  });
+
+  test('directBump package is covered when a fixed-group member is covered', () => {
+    const { missing } = resolveDirectBumpCoverage(['@cli/bin-darwin'], new Set(['cli']), packages, config);
+    expect(missing).toEqual([]);
+  });
+
+  test('uncovered directBump package stays missing with a hint naming bumpable members', () => {
+    const { missing, hints } = resolveDirectBumpCoverage(['@cli/bin-darwin', 'other'], new Set(), packages, config);
+    expect(missing).toEqual(['@cli/bin-darwin', 'other']);
+    expect(hints.get('@cli/bin-darwin')).toContain('cli');
+    expect(hints.has('other')).toBe(false);
+  });
+
+  test('directBump package outside any fixed group gets a generic hint', () => {
+    const loosePackages = new Map([['loner', makePkg('loner', '1.0.0', { bumpy: { directBump: false } })]]);
+    const { missing, hints } = resolveDirectBumpCoverage(['loner'], new Set(), loosePackages, makeConfig());
+    expect(missing).toEqual(['loner']);
+    expect(hints.get('loner')).toContain('fixed group');
   });
 });

--- a/packages/bumpy/test/core/release-plan.test.ts
+++ b/packages/bumpy/test/core/release-plan.test.ts
@@ -362,6 +362,114 @@ describe('assembleReleasePlan', () => {
         { name: 'plugin-a', newVersion: '2.1.0', bumpType: 'minor' }, // from linked group upgrade
       ]);
     });
+
+    test('drifted fixed group syncs all members to a bump of the highest version', () => {
+      const packages = new Map([
+        ['core', makePkg('core', '1.2.0')],
+        ['bin', makePkg('bin', '1.0.3')], // drifted below core
+      ]);
+
+      const bumpFiles: BumpFile[] = [{ id: 'cs1', releases: [{ name: 'core', type: 'minor' }], summary: 'Feature' }];
+      const graph = new DependencyGraph(packages);
+      const config = makeConfig({ fixed: [['core', 'bin']] });
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, config);
+
+      const core = plan.releases.find((r) => r.name === 'core')!;
+      const bin = plan.releases.find((r) => r.name === 'bin')!;
+      // Both bump from the group's highest version (1.2.0), reconverging the group
+      expect(core.newVersion).toBe('1.3.0');
+      expect(bin.oldVersion).toBe('1.0.3');
+      expect(bin.newVersion).toBe('1.3.0');
+      expect(plan.warnings.some((w) => w.includes('drifted') && w.includes('bin@1.0.3'))).toBe(true);
+    });
+
+    test('in-sync fixed group produces no drift warning', () => {
+      const packages = new Map([
+        ['core', makePkg('core', '1.0.0')],
+        ['bin', makePkg('bin', '1.0.0')],
+      ]);
+      const bumpFiles: BumpFile[] = [{ id: 'cs1', releases: [{ name: 'core', type: 'patch' }], summary: 'Fix' }];
+      const graph = new DependencyGraph(packages);
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, makeConfig({ fixed: [['core', 'bin']] }));
+
+      expect(plan.releases.every((r) => r.newVersion === '1.0.1')).toBe(true);
+      expect(plan.warnings.filter((w) => w.includes('drifted'))).toHaveLength(0);
+    });
+
+    test('drifted fixed group: Phase A range checks use the synced version', () => {
+      // core is dragged from 1.0.0 to 2.0.1 by its drifted group — app's ^1.0.0
+      // range on core must be detected as broken against the synced version.
+      const packages = new Map([
+        ['core', makePkg('core', '1.0.0')],
+        ['types', makePkg('types', '2.0.0')],
+        ['app', makePkg('app', '1.0.0', { dependencies: { core: '^1.0.0' } })],
+      ]);
+      const bumpFiles: BumpFile[] = [{ id: 'cs1', releases: [{ name: 'types', type: 'patch' }], summary: 'Fix' }];
+      const graph = new DependencyGraph(packages);
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, makeConfig({ fixed: [['core', 'types']] }));
+
+      const byName = new Map(plan.releases.map((r) => [r.name, r]));
+      expect(byName.get('core')!.newVersion).toBe('2.0.1');
+      expect(byName.get('app')).toBeDefined(); // out-of-range dep bump triggered
+      expect(byName.get('app')!.type).toBe('patch');
+    });
+  });
+
+  // ---- directBump: false ----
+
+  describe('directBump: false', () => {
+    const makeBinPackages = () =>
+      new Map([
+        ['cli', makePkg('cli', '1.0.0')],
+        ['@cli/bin-darwin', makePkg('@cli/bin-darwin', '1.0.0', { bumpy: { directBump: false } })],
+        ['@cli/bin-linux', makePkg('@cli/bin-linux', '1.0.0', { bumpy: { directBump: false } })],
+      ]);
+
+    test('group bumps still flow to directBump: false members', () => {
+      const packages = makeBinPackages();
+      const bumpFiles: BumpFile[] = [{ id: 'cs1', releases: [{ name: 'cli', type: 'minor' }], summary: 'Feature' }];
+      const graph = new DependencyGraph(packages);
+      const config = makeConfig({ fixed: [['cli', '@cli/bin-*']] });
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, config);
+
+      expect(plan.releases).toHaveLength(3);
+      const darwin = plan.releases.find((r) => r.name === '@cli/bin-darwin')!;
+      expect(darwin.type).toBe('minor');
+      expect(darwin.newVersion).toBe('1.1.0');
+      expect(darwin.isGroupBump).toBe(true);
+    });
+
+    test('bump file directly naming a directBump: false package throws', () => {
+      const packages = makeBinPackages();
+      const bumpFiles: BumpFile[] = [
+        { id: 'cs1', releases: [{ name: '@cli/bin-darwin', type: 'patch' }], summary: 'Oops' },
+      ];
+      const graph = new DependencyGraph(packages);
+      const config = makeConfig({ fixed: [['cli', '@cli/bin-*']] });
+
+      expect(() => assembleReleasePlan(bumpFiles, packages, graph, config)).toThrow(/directBump/);
+      expect(() => assembleReleasePlan(bumpFiles, packages, graph, config)).toThrow(/@cli\/bin-darwin/);
+    });
+
+    test('type "none" for a directBump: false package is allowed', () => {
+      const packages = makeBinPackages();
+      const bumpFiles: BumpFile[] = [
+        {
+          id: 'cs1',
+          releases: [
+            { name: 'cli', type: 'patch' },
+            { name: '@cli/bin-darwin', type: 'none' },
+          ],
+          summary: 'Fix',
+        },
+      ];
+      const graph = new DependencyGraph(packages);
+      const config = makeConfig({ fixed: [['cli', '@cli/bin-*']] });
+      const plan = assembleReleasePlan(bumpFiles, packages, graph, config);
+
+      // All three release via the group, none rejected
+      expect(plan.releases.map((r) => r.newVersion)).toEqual(['1.0.1', '1.0.1', '1.0.1']);
+    });
   });
 
   // ---- Phase C: proactive propagation ----

--- a/skills/add-change/SKILL.md
+++ b/skills/add-change/SKILL.md
@@ -123,6 +123,7 @@ It's a file-level flag (a bump file has one shared body), so it applies to every
 ## Important notes
 
 - Only include packages that have **actual code changes** — bumpy handles dependency propagation automatically
+- Never list a package configured with `directBump: false` (check `.bumpy/_config.json` `packages` and each `package.json` `"bumpy"` field) — such packages only receive propagated bumps; bump the package that drives them (e.g. their fixed-group member) instead
 - If the user hasn't made any changes yet, ask what they're planning to change
 - If the change doesn't affect any publishable packages (e.g., only root config files), suggest using `bumpy add --empty` to satisfy CI checks
 - One bump file per logical change — don't combine unrelated changes


### PR DESCRIPTION
## What

Two related changes for modeling platform-specific binary packages that version in lockstep with a core package (the esbuild/napi-rs pattern):

### `directBump: false` per-package config

A package marked `directBump: false` can only receive **propagated** bumps (fixed/linked group, cascade, dependency) — never direct ones:

- `bumpy add` excludes it from the interactive prompt, `--none` generation, and rejects it in `--packages`
- `bumpy generate` never suggests it from commit scopes or changed files
- a bump file that directly names it (with a type other than `none`) is an error at plan time, pointing at the driving package
- `bumpy check` counts its changes as covered when any other fixed-group member is covered, and the missing-package output hints at the bumpable group members

Typical config:

```jsonc
{
  "fixed": [["mycli", "@mycli/bin-*"]],
  "packages": { "@mycli/bin-*": { "directBump": false } }
}
```

### Fixed groups sync to highest

Previously Phase B only equalized the bump *type* — each member bumped from its own current version, so a drifted group (botched manual publish, package added late) never reconverged. Members now version from the group's **highest** current version: Phase A range checks, planned versions, and bump-source reporting all use the synced target, and the plan warns when drift is detected so the version jump is explained.

## Testing

- New release-plan tests: drift convergence, no-drift no-warning, Phase A range checks against synced versions, group bumps flowing to `directBump: false` members, direct-bump rejection, `none` allowed
- New check tests for the coverage-remap helper
- 427 tests pass; `tsc --noEmit` clean; `bumpy check` dogfooded on this repo

Docs updated (configuration.md, version-propagation.md, config-schema.json, add-change skill).