### PR TITLE
ci: add pullfrog workflow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,45 @@
+# PULLFROG ACTION — DO NOT EDIT EXCEPT WHERE INDICATED
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    # Skip runs triggered by bumpy-bot (the automated "Versioned release" PRs on
+    # bumpy/version-packages). Every push to main refreshes that PR, which would
+    # otherwise trigger a paid re-review each time. Human-triggered runs on that
+    # PR (e.g. an @pullfrog mention) still execute, since the triggerer is the human.
+    if: ${{ !contains(inputs.prompt, '"triggerer":"bumpy-bot"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Run agent
+        uses: pullfrog/pullfrog@v0
+        with:
+          prompt: ${{ inputs.prompt }}
+        env:
+          # Review with GPT Sol via our Azure Foundry deployment instead of the
+          # default Anthropic route. AZURE_API_KEY comes from the Pullfrog
+          # dashboard; these two are set here so they stay readable in run logs
+          # (dashboard-stored values get registered as GitHub Actions log masks).
+          # The Azure deployment must be named exactly `gpt-5.6-sol`: the
+          # @ai-sdk/azure provider uses the model id as the deployment name.
+          AZURE_RESOURCE_NAME: pullfrog-resource
+          PULLFROG_MODEL: azure/gpt-5.6-sol


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pullfrog.yml`, mirrored from varlock's copy
- Includes the Azure GPT-5.6-Sol routing (`AZURE_RESOURCE_NAME`/`PULLFROG_MODEL`) and the bumpy-bot skip logic for `bumpy/version-packages` refresh runs

## Test plan
- [ ] Pullfrog app installed + `AZURE_API_KEY` configured for this repo in the Pullfrog dashboard
- [ ] Trigger a run (e.g. `@pullfrog` mention on a PR) and confirm it executes
- [ ] Confirm a bumpy-bot-triggered run on `bumpy/version-packages` is skipped