### PR TITLE
chore: replace semver with verkit

### DIFF
--- a/.bumpy/replace-semver-with-verkit.md
+++ b/.bumpy/replace-semver-with-verkit.md
@@ -1,0 +1,5 @@
+---
+'@varlock/bumpy': patch
+---
+
+Replaced the `semver` dependency with [verkit](https://github.com/sxzz/verkit) — a smaller, tree-shakeable, zero-dependency SemVer library. No behavior changes, except invalid snapshot versions are now also refused (previously only stable versions were).

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/bumpy": {
       "name": "@varlock/bumpy",
-      "version": "1.16.1",
+      "version": "1.18.1",
       "bin": {
         "bumpy": "./dist/cli.mjs",
       },
@@ -23,13 +23,12 @@
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
         "@types/picomatch": "^4.0.3",
-        "@types/semver": "^7.7.0",
         "js-yaml": "^4.1.0",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.4",
-        "semver": "^7.7.2",
         "tsdown": "catalog:",
         "typescript": "catalog:",
+        "verkit": "^0.4.0",
       },
     },
     "packages/website": {
@@ -198,8 +197,6 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
-    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
-
     "@varlock/bumpy": ["@varlock/bumpy@workspace:packages/bumpy"],
 
     "@varlock/bumpy-website": ["@varlock/bumpy-website@workspace:packages/website"],
@@ -309,5 +306,7 @@
     "unrun": ["unrun@0.2.35", "", { "dependencies": { "rolldown": "1.0.0-rc.15" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-nDP7mA4Fu5owDarQtLiiN3lq7tJZHFEAVIchnwP8U3wMeEkLoUNT37Hva85H05Rdw8CArpGmtY+lBjpk9fruVQ=="],
 
     "varlock": ["varlock@0.8.1", "", { "bin": { "varlock": "bin/cli.js" } }, "sha512-ZvIeQa493AKNqh2BaB96WLksN4R4rceWxbPFto9XbFpzqX00WgI8NhYxkrMw+WDDuTL0ca8mWss6l9u2gwKpRA=="],
+
+    "verkit": ["verkit@0.4.0", "", {}, "sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g=="],
   }
 }

--- a/packages/bumpy/package.json
+++ b/packages/bumpy/package.json
@@ -47,13 +47,12 @@
     "@types/bun": "latest",
     "@types/js-yaml": "^4.0.9",
     "@types/picomatch": "^4.0.3",
-    "@types/semver": "^7.7.0",
     "js-yaml": "^4.1.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4",
-    "semver": "^7.7.2",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "verkit": "^0.4.0"
   },
   "bumpy": {
     "releaseTriggeringDevDeps": [
@@ -61,7 +60,7 @@
       "js-yaml",
       "picocolors",
       "picomatch",
-      "semver"
+      "verkit"
     ]
   }
 }

--- a/packages/bumpy/src/commands/publish.ts
+++ b/packages/bumpy/src/commands/publish.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import { isPrerelease } from 'verkit';
 import { log, colorize } from '../utils/logger.ts';
 import { loadConfig } from '../core/config.ts';
 import { discoverWorkspace } from '../core/workspace.ts';
@@ -107,7 +107,7 @@ export async function publishCommand(
   // happen — committed versions are always stable — so a suffixed version here
   // means something went wrong. Refuse loudly rather than publish it.
   if (Object.keys(config.channels || {}).length > 0) {
-    const prereleases = toPublish.filter((r) => semver.prerelease(r.newVersion) !== null);
+    const prereleases = toPublish.filter((r) => isPrerelease(r.newVersion) === true);
     if (prereleases.length > 0) {
       log.error('Refusing to publish prerelease versions outside a channel:');
       for (const r of prereleases) log.error(`  • ${r.name}@${r.newVersion}`);
@@ -490,7 +490,7 @@ async function runPublishFlow(
 
         try {
           await createDraftRelease(tag, title, body, rootDir, headSha || undefined, {
-            prerelease: semver.prerelease(release.newVersion) !== null,
+            prerelease: isPrerelease(release.newVersion) === true,
           });
           log.dim(`  Created draft release: ${title}`);
           releaseMetadataByPkg.set(release.name, { tag, metadata, existingBody: body });

--- a/packages/bumpy/src/core/prerelease.ts
+++ b/packages/bumpy/src/core/prerelease.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import semver from 'semver';
+import { tryParse } from 'verkit';
 import { readText, writeText, updateJsonFields, updateJsonNestedField } from '../utils/fs.ts';
 import { runArgsAsync, tryRunArgs } from '../utils/shell.ts';
 import { listTags } from './git.ts';
@@ -29,12 +29,13 @@ export interface PublishedPrereleaseState {
 export function extractPrereleaseCounters(versions: string[], target: string, preid: string): number[] {
   const counters: number[] = [];
   for (const v of versions) {
-    const parsed = semver.parse(v);
+    const parsed = tryParse(v);
     if (!parsed) continue;
     if (`${parsed.major}.${parsed.minor}.${parsed.patch}` !== target) continue;
-    if (parsed.prerelease.length !== 2) continue;
-    if (parsed.prerelease[0] !== preid) continue;
-    const n = parsed.prerelease[1];
+    const prerelease = parsed.prerelease ?? [];
+    if (prerelease.length !== 2) continue;
+    if (prerelease[0] !== preid) continue;
+    const n = prerelease[1];
     if (typeof n === 'number') counters.push(n);
   }
   return counters;

--- a/packages/bumpy/src/core/semver.ts
+++ b/packages/bumpy/src/core/semver.ts
@@ -1,8 +1,8 @@
-import semver from 'semver';
+import { compare, increment, isValid, satisfies as verkitSatisfies } from 'verkit';
 import type { BumpType } from '../types.ts';
 
 export function bumpVersion(version: string, type: BumpType): string {
-  const result = semver.inc(version, type);
+  const result = increment(version, type);
   if (!result) throw new Error(`Failed to bump ${version} by ${type}`);
   return result;
 }
@@ -21,16 +21,16 @@ export function satisfies(version: string, range: string, currentVersion?: strin
     if (cleanRange === '^' || cleanRange === '~') {
       if (!currentVersion) return true; // can't resolve without current version
       const resolved = `${cleanRange}${currentVersion}`;
-      return semver.satisfies(version, resolved);
+      return verkitSatisfies(version, resolved);
     }
-    return semver.satisfies(version, cleanRange);
+    return verkitSatisfies(version, cleanRange);
   }
   // catalog: references can't be range-checked without catalog data,
   // so treat them as always satisfied (don't trigger out-of-range bumps)
   if (range.startsWith('catalog:')) return true;
 
   if (!range || range === '*') return true;
-  return semver.satisfies(version, range);
+  return verkitSatisfies(version, range);
 }
 
 /** Strip workspace: protocol from version ranges */
@@ -40,9 +40,9 @@ export function stripProtocol(range: string): string {
 
 /** Compare two versions: -1 if a < b, 0 if equal, 1 if a > b */
 export function compareVersions(a: string, b: string): number {
-  return semver.compare(a, b);
+  return compare(a, b);
 }
 
 export function isValidVersion(version: string): boolean {
-  return semver.valid(version) !== null;
+  return isValid(version);
 }

--- a/packages/bumpy/src/core/snapshot.ts
+++ b/packages/bumpy/src/core/snapshot.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import { isPrerelease } from 'verkit';
 import { tryRunArgs } from '../utils/shell.ts';
 import { fetchPublishedVersions, usesNpmRegistry } from './prerelease.ts';
 import type { BumpyConfig, ReleasePlan, PlannedRelease, WorkspacePackage } from '../types.ts';
@@ -161,7 +161,7 @@ export function formatSnapshotVersionSummary(releases: PlannedRelease[]): string
 
 /** Guard: a snapshot version must be a valid prerelease (never collides with a stable release) */
 export function assertSnapshotPrerelease(version: string): void {
-  if (semver.prerelease(version) === null) {
+  if (isPrerelease(version) !== true) {
     throw new Error(`Snapshot version "${version}" is not a prerelease — refusing to publish (would land on @latest).`);
   }
 }

--- a/packages/bumpy/test/core/snapshot.test.ts
+++ b/packages/bumpy/test/core/snapshot.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import semver from 'semver';
+import { isLess, isPrerelease, isValid, normalize } from 'verkit';
 import {
   sanitizeSnapshotName,
   resolveSnapshot,
@@ -28,7 +28,7 @@ describe('sanitizeSnapshotName', () => {
 
   test('produces a valid semver prerelease identifier', () => {
     const name = sanitizeSnapshotName('feature/Foo_Bar');
-    expect(semver.valid(`1.2.3-${name}.0`)).not.toBeNull();
+    expect(isValid(`1.2.3-${name}.0`)).toBe(true);
   });
 
   test('throws when nothing alphanumeric remains', () => {
@@ -94,19 +94,19 @@ describe('snapshotVersion', () => {
   test('sha → <target>-<name>-<sha>', () => {
     const v = snapshotVersion('1.4.0', base({ strategy: 'sha', suffix: 'a1b2c3d' }));
     expect(v).toBe('1.4.0-pr-123-a1b2c3d');
-    expect(semver.valid(v)).toBe(v);
-    expect(semver.prerelease(v)).not.toBeNull();
+    expect(normalize(v)).toBe(v);
+    expect(isPrerelease(v)).toBe(true);
   });
 
   test('timestamp → <target>-<name>-<timestamp>', () => {
     const v = snapshotVersion('2.0.0', base({ strategy: 'timestamp', suffix: '20260623123456' }));
     expect(v).toBe('2.0.0-pr-123-20260623123456');
-    expect(semver.valid(v)).toBe(v);
+    expect(normalize(v)).toBe(v);
   });
 
   test('snapshot versions sort below their stable target', () => {
     const v = snapshotVersion('1.4.0', base({}));
-    expect(semver.lt(v, '1.4.0')).toBe(true);
+    expect(isLess(v, '1.4.0')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Replaces the `semver` dependency (plus `@types/semver`) with [verkit](https://github.com/sxzz/verkit) — a zero-dependency, tree-shakeable SemVer library with native TypeScript types.

The API mapped nearly 1:1; the differences that needed handling:

- `semver.prerelease(v) === null` checks → `isPrerelease(v)`: verkit's `getPrerelease('1.2.3')` returns `[]` rather than `null` for stable versions. The snapshot guard now uses `isPrerelease(version) !== true`, which also refuses *invalid* versions (previously only stable ones) — strictly safer.
- `semver.parse` returned `null` on invalid input; verkit's `parse` throws, so prerelease counter extraction uses `tryParse`. verkit also omits the `prerelease` field entirely for stable versions, so the counter check defaults it to `[]`.
- Tests: `semver.valid(v)).toBe(v)` → `normalize(v)).toBe(v)`, `semver.lt` → `isLess`.

Verified at runtime that `satisfies`/`increment`/`compare` match node-semver's contracts (string ranges accepted, `false` on invalid range, `null` on failed increment, throw on comparing invalid versions). verkit is bundled into dist by tsdown as a devDependency, same as semver was; `releaseTriggeringDevDeps` updated accordingly.

All 427 tests pass; typecheck, lint, and build are clean.